### PR TITLE
Add multi-mode gameplay with animated results and new theme

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { palette } from "../src/theme";
 
 export default function Layout() {
   return (
@@ -8,9 +9,9 @@ export default function Layout() {
       <StatusBar style="light" />
       <Stack
         screenOptions={{
-          headerStyle: { backgroundColor: "#0B0B10" },
-          headerTintColor: "#ECEFF4",
-          contentStyle: { backgroundColor: "#0B0B10" },
+          headerStyle: { backgroundColor: palette.background },
+          headerTintColor: palette.textPrimary,
+          contentStyle: { backgroundColor: palette.background },
         }}
       >
         <Stack.Screen name="index" options={{ headerShown: false }} />
@@ -18,6 +19,8 @@ export default function Layout() {
         <Stack.Screen name="main" options={{ title: "Main Menu" }} />
         <Stack.Screen name="gamemodes" options={{ title: "Play" }} />
         <Stack.Screen name="simple" options={{ title: "Simple Mode" }} />
+        <Stack.Screen name="normal" options={{ title: "Normal Mode" }} />
+        <Stack.Screen name="pro" options={{ title: "Pro Mode" }} />
         <Stack.Screen name="leaderboard" options={{ title: "Leaderboard" }} />
       </Stack>
     </>

--- a/app/gamemodes.tsx
+++ b/app/gamemodes.tsx
@@ -1,19 +1,71 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Text } from "react-native";
 import { router } from "expo-router";
 import { MenuButton } from "../src/ui";
+import { palette } from "../src/theme";
+
+const modes = [
+  {
+    title: "Simple",
+    subtitle: "Static archery target. Remember its spot.",
+    path: "/simple",
+  },
+  {
+    title: "Normal",
+    subtitle: "Horizontal glide. Predict the slide while blind.",
+    path: "/normal",
+  },
+  {
+    title: "Pro",
+    subtitle: "Full-field movement. Track both axes at once.",
+    path: "/pro",
+  },
+];
 
 export default function GamemodeScreen() {
   return (
     <View style={styles.safe}>
       <View style={styles.container}>
-        <MenuButton title="Simple (Guess X)" onPress={() => router.push("/simple")} />
+        <Text style={styles.title}>Choose your challenge</Text>
+        {modes.map((mode) => (
+          <View key={mode.title} style={styles.option}>
+            <MenuButton title={mode.title} onPress={() => router.push(mode.path)} style={styles.optionButton} />
+            <Text style={styles.subtitle}>{mode.subtitle}</Text>
+          </View>
+        ))}
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: "#0B0B10" },
-  container: { flex: 1, justifyContent: "center", padding: 20 },
+  safe: { flex: 1, backgroundColor: palette.background },
+  container: { flex: 1, justifyContent: "center", padding: 24 },
+  title: {
+    color: palette.textPrimary,
+    fontSize: 24,
+    fontWeight: "700",
+    marginBottom: 24,
+  },
+  option: {
+    backgroundColor: palette.surface,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
+    shadowColor: "#04110A",
+    shadowOpacity: 0.35,
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 16,
+    elevation: 6,
+  },
+  optionButton: {
+    marginVertical: 0,
+  },
+  subtitle: {
+    color: palette.textSecondary,
+    fontSize: 13,
+    marginTop: 8,
+  },
 });

--- a/app/leaderboard.tsx
+++ b/app/leaderboard.tsx
@@ -3,6 +3,13 @@ import { ActivityIndicator, FlatList, StyleSheet, Text, View } from "react-nativ
 import { useFocusEffect } from "@react-navigation/native";
 import { getScores } from "../src/storage";
 import type { ScorePayload } from "../src/types";
+import { palette } from "../src/theme";
+
+const modeLabels: Record<ScorePayload["mode"], string> = {
+  SIMPLE: "Simple",
+  NORMAL: "Normal",
+  PRO: "Pro",
+};
 
 export default function LeaderboardScreen() {
   const [data, setData] = useState<ScorePayload[]>([]);
@@ -29,13 +36,19 @@ export default function LeaderboardScreen() {
     }, [loadScores])
   );
 
-  if (loading) return <ActivityIndicator style={{ marginTop: 40 }} />;
-  if (error) return <Text style={{ color: "#EF4444", padding: 16 }}>{error}</Text>;
+  if (loading)
+    return <ActivityIndicator style={{ marginTop: 40 }} color={palette.accent} size="large" />;
+  if (error)
+    return (
+      <View style={styles.safe}>
+        <Text style={styles.error}>{error}</Text>
+      </View>
+    );
 
   if (!data.length) {
     return (
       <View style={styles.safe}>
-        <Text style={{ color: "#A3A8C3", padding: 16 }}>No scores saved yet. Play a round!</Text>
+        <Text style={styles.empty}>No scores saved yet. Play a round!</Text>
       </View>
     );
   }
@@ -51,9 +64,10 @@ export default function LeaderboardScreen() {
             <Text style={styles.rank}>{index + 1}.</Text>
             <View style={styles.rowContent}>
               <Text style={styles.name}>{item.nickname}</Text>
-              <Text style={styles.meta}>
-                {`${Math.round(item.distancePx)}px · ${item.reactionMs}ms`}
-              </Text>
+              <View style={styles.metaRow}>
+                <Text style={styles.modeBadge}>{modeLabels[item.mode]}</Text>
+                <Text style={styles.meta}>{`${Math.round(item.distancePx)}px · ${item.reactionMs}ms`}</Text>
+              </View>
             </View>
             <Text style={styles.score}>{item.score}</Text>
           </View>
@@ -64,19 +78,41 @@ export default function LeaderboardScreen() {
 }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: "#0B0B10" },
+  safe: { flex: 1, backgroundColor: palette.background },
   row: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    backgroundColor: "#141420",
-    borderRadius: 12,
-    padding: 12,
-    marginBottom: 8,
+    backgroundColor: palette.surface,
+    borderRadius: 14,
+    padding: 14,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: palette.border,
+    shadowColor: "#04110A",
+    shadowOpacity: 0.3,
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 14,
+    elevation: 5,
   },
   rowContent: { flex: 1, marginLeft: 12 },
-  rank: { color: "#A3A8C3", width: 28, textAlign: "right" },
-  name: { color: "#ECEFF4", fontWeight: "700" },
-  meta: { color: "#A3A8C3", fontSize: 12, marginTop: 2 },
-  score: { color: "#A5B4FC", fontWeight: "700" },
+  rank: { color: palette.textSecondary, width: 28, textAlign: "right" },
+  name: { color: palette.textPrimary, fontWeight: "700", fontSize: 16 },
+  metaRow: { flexDirection: "row", alignItems: "center", marginTop: 6 },
+  modeBadge: {
+    backgroundColor: palette.surfaceAlt,
+    color: palette.textPrimary,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: palette.border,
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  meta: { color: palette.textSecondary, fontSize: 12, marginLeft: 10 },
+  score: { color: palette.accent, fontWeight: "800", fontSize: 18 },
+  empty: { color: palette.textSecondary, padding: 16 },
+  error: { color: palette.negative, padding: 16 },
 });

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -1,21 +1,30 @@
 import React from "react";
-import { View, StyleSheet, BackHandler } from "react-native";
+import { View, StyleSheet, BackHandler, Text } from "react-native";
 import { router } from "expo-router";
 import { MenuButton } from "../src/ui";
+import { palette } from "../src/theme";
 
 export default function MainMenuScreen() {
   return (
     <View style={styles.safe}>
       <View style={styles.container}>
-        <MenuButton title="Play" onPress={() => router.push("/gamemodes")} />
-        <MenuButton title="Leaderboard" onPress={() => router.push("/leaderboard")} />
-        <MenuButton title="Exit" onPress={() => BackHandler.exitApp()} />
+        <Text style={styles.title}>Predict Aim</Text>
+        <Text style={styles.subtitle}>Sharpen your prediction timing across dynamic targets.</Text>
+        <View style={styles.buttonGroup}>
+          <MenuButton title="Play" onPress={() => router.push("/gamemodes")} style={styles.menuBtn} />
+          <MenuButton title="Leaderboard" onPress={() => router.push("/leaderboard")} style={styles.menuBtn} />
+          <MenuButton title="Exit" onPress={() => BackHandler.exitApp()} style={styles.menuBtn} />
+        </View>
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: "#0B0B10" },
-  container: { flex: 1, justifyContent: "center", padding: 20 },
+  safe: { flex: 1, backgroundColor: palette.background },
+  container: { flex: 1, justifyContent: "center", padding: 24 },
+  title: { color: palette.textPrimary, fontSize: 30, fontWeight: "800" },
+  subtitle: { color: palette.textSecondary, fontSize: 14, marginTop: 8, marginBottom: 28 },
+  buttonGroup: {},
+  menuBtn: { marginVertical: 6 },
 });

--- a/app/nickname.tsx
+++ b/app/nickname.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, StyleSheet, KeyboardAvoidingView, Platform } fro
 import { router } from "expo-router";
 import { saveNickname } from "../src/storage";
 import { MenuButton } from "../src/ui";
+import { palette } from "../src/theme";
 
 export default function NicknameScreen() {
   const [name, setName] = useState("");
@@ -20,7 +21,7 @@ export default function NicknameScreen() {
         <Text style={styles.title}>Pick a nickname</Text>
         <TextInput
           placeholder="At least 3 characters"
-          placeholderTextColor="#A3A8C3"
+          placeholderTextColor={palette.textSecondary}
           style={styles.input}
           value={name}
           onChangeText={setName}
@@ -35,16 +36,16 @@ export default function NicknameScreen() {
 }
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: "#0B0B10" },
-  container: { flex: 1, justifyContent: "center", padding: 20 },
-  title: { color: "#ECEFF4", fontSize: 22, fontWeight: "700", marginBottom: 12 },
+  safe: { flex: 1, backgroundColor: palette.background },
+  container: { flex: 1, justifyContent: "center", padding: 24 },
+  title: { color: palette.textPrimary, fontSize: 24, fontWeight: "700", marginBottom: 12 },
   input: {
-    backgroundColor: "#141420",
-    color: "#ECEFF4",
+    backgroundColor: palette.surface,
+    color: palette.textPrimary,
     padding: 12,
-    borderRadius: 10,
+    borderRadius: 12,
     borderWidth: 1,
-    borderColor: "#23233A",
+    borderColor: palette.border,
     marginBottom: 16,
   },
 });

--- a/app/normal.tsx
+++ b/app/normal.tsx
@@ -2,6 +2,6 @@ import React from "react";
 import { router } from "expo-router";
 import { GameScreen } from "../src/gameplay";
 
-export default function SimpleModeScreen() {
-  return <GameScreen mode="SIMPLE" onExit={() => router.back()} />;
+export default function NormalModeScreen() {
+  return <GameScreen mode="NORMAL" onExit={() => router.back()} />;
 }

--- a/app/pro.tsx
+++ b/app/pro.tsx
@@ -2,6 +2,6 @@ import React from "react";
 import { router } from "expo-router";
 import { GameScreen } from "../src/gameplay";
 
-export default function SimpleModeScreen() {
-  return <GameScreen mode="SIMPLE" onExit={() => router.back()} />;
+export default function ProModeScreen() {
+  return <GameScreen mode="PRO" onExit={() => router.back()} />;
 }

--- a/src/score.ts
+++ b/src/score.ts
@@ -1,7 +1,7 @@
-export function calculateScore(distancePx: number, reactionMs: number, screenWidth: number): number {
+export function calculateScore(distancePx: number, reactionMs: number, maxDistance: number): number {
   const baseScore = 1000;
-  const clampedDistance = Math.min(distancePx, screenWidth);
-  const distancePenalty = clampedDistance * 0.5;
-  const timePenalty = Math.max(0, reactionMs - 100) * 0.5;
+  const clampedDistance = Math.min(distancePx, maxDistance);
+  const distancePenalty = (clampedDistance / maxDistance) * 650;
+  const timePenalty = Math.max(0, reactionMs - 150) * 0.4;
   return Math.max(0, Math.round(baseScore - distancePenalty - timePenalty));
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,19 @@
+export const palette = {
+  background: "#0D1510",
+  surface: "#16201B",
+  surfaceAlt: "#1E2A24",
+  overlay: "rgba(10, 24, 17, 0.88)",
+  overlayHeavy: "rgba(6, 18, 12, 0.94)",
+  border: "#243830",
+  accent: "#2F9B6F",
+  accentMuted: "#1F6E4E",
+  textPrimary: "#E7F3EA",
+  textSecondary: "#9CBFA9",
+  positive: "#4ADE80",
+  negative: "#F87171",
+};
+
+export const typography = {
+  heading: { color: palette.textPrimary, fontSize: 22, fontWeight: "700" as const },
+  body: { color: palette.textSecondary, fontSize: 14 },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,15 @@
-export type GameMode = "SIMPLE";
+export type GameMode = "SIMPLE" | "NORMAL" | "PRO";
 export interface ScorePayload {
   nickname: string;
   mode: GameMode;
   distancePx: number;
   reactionMs: number;
   screenWidth: number;
+  screenHeight: number;
   targetX: number;
+  targetY: number;
   guessX: number;
+  guessY: number;
   timestamp: string;
   score: number;
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { TouchableOpacity, Text, StyleSheet, ViewStyle } from "react-native";
+import { palette } from "./theme";
 export function MenuButton({ title, onPress, style }: { title: string; onPress: () => void; style?: ViewStyle }) {
   return (
-    <TouchableOpacity onPress={onPress} style={[styles.btn, style]} activeOpacity={0.8}>
+    <TouchableOpacity onPress={onPress} style={[styles.btn, style]} activeOpacity={0.82}>
       <Text style={styles.btnText}>{title}</Text>
     </TouchableOpacity>
   );
@@ -11,10 +12,17 @@ const styles = StyleSheet.create({
   btn: {
     paddingVertical: 14,
     paddingHorizontal: 18,
-    backgroundColor: "#4F46E5",
+    backgroundColor: palette.accent,
     borderRadius: 12,
     marginVertical: 8,
     alignItems: "center",
+    borderWidth: 1,
+    borderColor: palette.accentMuted,
+    shadowColor: "#03140C",
+    shadowOpacity: 0.35,
+    shadowOffset: { width: 0, height: 6 },
+    shadowRadius: 14,
+    elevation: 4,
   },
-  btnText: { color: "#ECEFF4", fontSize: 16, fontWeight: "700" },
+  btnText: { color: palette.textPrimary, fontSize: 16, fontWeight: "700" },
 });


### PR DESCRIPTION
## Summary
- add a reusable game screen that powers simple, normal, and pro modes with moving archery targets, predictive blackout, and animated in-game results
- refresh the app with a green-tinted palette applied to menus, modal flows, and navigation
- extend stored scores and leaderboard presentation to cover the new modes and richer telemetry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd3acbd2c48330bb159e8a244a8abc