### PR TITLE
Add extreme mode, multiplayer flow, and improved leaderboard

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,7 +21,9 @@ export default function Layout() {
         <Stack.Screen name="simple" options={{ title: "Simple Mode" }} />
         <Stack.Screen name="normal" options={{ title: "Normal Mode" }} />
         <Stack.Screen name="pro" options={{ title: "Pro Mode" }} />
+        <Stack.Screen name="extreme" options={{ title: "Extreme Mode" }} />
         <Stack.Screen name="leaderboard" options={{ title: "Leaderboard" }} />
+        <Stack.Screen name="local" options={{ title: "Local Multiplayer" }} />
       </Stack>
     </>
   );

--- a/app/extreme.tsx
+++ b/app/extreme.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { router } from "expo-router";
+import { GameScreen } from "../src/gameplay";
+
+export default function ExtremeModeScreen() {
+  return <GameScreen mode="EXTREME" onExit={() => router.back()} />;
+}

--- a/app/gamemodes.tsx
+++ b/app/gamemodes.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, StyleSheet, Text } from "react-native";
 import { router } from "expo-router";
-import { MenuButton } from "../src/ui";
+import { MenuButton, PlayerSwitcher } from "../src/ui";
 import { palette } from "../src/theme";
 
 const modes = [
@@ -20,14 +20,37 @@ const modes = [
     subtitle: "Full-field movement. Track both axes at once.",
     path: "/pro",
   },
+  {
+    title: "Extreme",
+    subtitle: "Two targets at once. Double the challenge.",
+    path: "/extreme",
+  },
+];
+
+const extras = [
+  {
+    title: "Local Multiplayer",
+    subtitle: "Face off across three rounds of five shots each.",
+    path: "/local",
+  },
 ];
 
 export default function GamemodeScreen() {
   return (
     <View style={styles.safe}>
       <View style={styles.container}>
-        <Text style={styles.title}>Choose your challenge</Text>
+        <View style={styles.titleRow}>
+          <Text style={styles.title}>Choose your challenge</Text>
+          <PlayerSwitcher style={styles.switcher} />
+        </View>
         {modes.map((mode) => (
+          <View key={mode.title} style={styles.option}>
+            <MenuButton title={mode.title} onPress={() => router.push(mode.path)} style={styles.optionButton} />
+            <Text style={styles.subtitle}>{mode.subtitle}</Text>
+          </View>
+        ))}
+        <Text style={styles.sectionLabel}>Party modes</Text>
+        {extras.map((mode) => (
           <View key={mode.title} style={styles.option}>
             <MenuButton title={mode.title} onPress={() => router.push(mode.path)} style={styles.optionButton} />
             <Text style={styles.subtitle}>{mode.subtitle}</Text>
@@ -41,12 +64,13 @@ export default function GamemodeScreen() {
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: palette.background },
   container: { flex: 1, justifyContent: "center", padding: 24 },
+  titleRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 12 },
   title: {
     color: palette.textPrimary,
     fontSize: 24,
     fontWeight: "700",
-    marginBottom: 24,
   },
+  switcher: { marginLeft: 16 },
   option: {
     backgroundColor: palette.surface,
     borderRadius: 16,
@@ -67,5 +91,13 @@ const styles = StyleSheet.create({
     color: palette.textSecondary,
     fontSize: 13,
     marginTop: 8,
+  },
+  sectionLabel: {
+    color: palette.textSecondary,
+    fontSize: 12,
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    marginTop: 12,
+    marginBottom: 10,
   },
 });

--- a/app/leaderboard.tsx
+++ b/app/leaderboard.tsx
@@ -1,17 +1,19 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, FlatList, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
-import { getActivePlayer, getScores } from "../src/storage";
+import { getActivePlayer, getScores, subscribeActivePlayer } from "../src/storage";
 import type { GameMode, PlayerProfile, ScorePayload } from "../src/types";
 import { palette } from "../src/theme";
+import { PlayerSwitcher } from "../src/ui";
 
 const modeLabels: Record<GameMode, string> = {
   SIMPLE: "Simple",
   NORMAL: "Normal",
   PRO: "Pro",
+  EXTREME: "Extreme",
 };
 
-const modes: GameMode[] = ["SIMPLE", "NORMAL", "PRO"];
+const modes: GameMode[] = ["SIMPLE", "NORMAL", "PRO", "EXTREME"];
 
 const sortOptions = [
   { key: "score", label: "Score" },
@@ -148,21 +150,45 @@ function MetricChart({ data, label, unit, color, accessor, isLowerBetter }: Metr
   });
 
   const bestValue = isLowerBetter ? Math.min(...values) : Math.max(...values);
+  const bestIndex = values.findIndex((value) => value === bestValue);
   const latestValue = values[values.length - 1];
+  const previousValue = values.length > 1 ? values[values.length - 2] : null;
+  const change = previousValue === null ? null : latestValue - previousValue;
+  const changeLabel =
+    change === null
+      ? "New data"
+      : `${change > 0 ? "+" : ""}${Math.round(change)}${unit ? ` ${unit}` : ""}`;
+  const isImproving =
+    change === null ? null : isLowerBetter ? change < 0 : change > 0;
   const firstTimestamp = samples[0]?.item.timestamp;
   const lastTimestamp = samples[samples.length - 1]?.item.timestamp;
 
   return (
     <View style={styles.chartCard}>
       <View style={styles.chartHeader}>
-        <Text style={styles.chartTitle}>{label}</Text>
-        <Text style={styles.chartMeta}>Best {formatValue(bestValue, unit)}</Text>
+        <View>
+          <Text style={styles.chartTitle}>{label}</Text>
+          <Text style={styles.chartMeta}>Best {formatValue(bestValue, unit)}</Text>
+        </View>
+        <Text
+          style={[
+            styles.chartTrend,
+            isImproving === null
+              ? styles.chartTrendNeutral
+              : isImproving
+              ? styles.chartTrendPositive
+              : styles.chartTrendNegative,
+          ]}
+        >
+          {changeLabel}
+        </Text>
       </View>
       <View style={styles.chartBars}>
         {normalizedHeights.map((ratio, index) => {
           const sample = samples[index];
           const barHeight = 18 + ratio * 92;
           const isLast = index === normalizedHeights.length - 1;
+          const isBest = index === bestIndex;
           return (
             <View key={`${sample.item.timestamp}-${index}`} style={styles.chartBarTrack}>
               <View
@@ -173,6 +199,7 @@ function MetricChart({ data, label, unit, color, accessor, isLowerBetter }: Metr
                     backgroundColor: color,
                     opacity: isLast ? 1 : 0.65,
                   },
+                  isBest && styles.chartBarBest,
                 ]}
               />
             </View>
@@ -195,6 +222,7 @@ export default function LeaderboardScreen() {
   const [activeMode, setActiveMode] = useState<GameMode>("SIMPLE");
   const [sortKey, setSortKey] = useState<SortKey>("score");
   const [activePlayer, setActivePlayer] = useState<PlayerProfile | null>(null);
+  const [showCharts, setShowCharts] = useState(false);
 
   const loadScores = useCallback(async () => {
     setLoading(true);
@@ -218,6 +246,13 @@ export default function LeaderboardScreen() {
   );
 
   useEffect(() => {
+    const unsubscribe = subscribeActivePlayer((player) => {
+      setActivePlayer(player);
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
     if (!data.length) return;
     if (!data.some((entry) => entry.mode === activeMode)) {
       setActiveMode(data[0].mode);
@@ -230,7 +265,7 @@ export default function LeaderboardScreen() {
         acc[entry.mode] = (acc[entry.mode] ?? 0) + 1;
         return acc;
       },
-      { SIMPLE: 0, NORMAL: 0, PRO: 0 } as Record<GameMode, number>
+      { SIMPLE: 0, NORMAL: 0, PRO: 0, EXTREME: 0 } as Record<GameMode, number>
     );
   }, [data]);
 
@@ -241,6 +276,20 @@ export default function LeaderboardScreen() {
     copy.sort(comparators[sortKey]);
     return copy;
   }, [modeData, sortKey]);
+
+  const summary = useMemo(() => {
+    if (!modeData.length) return null;
+    const totalScore = modeData.reduce((sum, entry) => sum + entry.score, 0);
+    const bestScore = Math.max(...modeData.map((entry) => entry.score));
+    const averageScore = Math.round(totalScore / modeData.length);
+    const averageReaction = Math.round(
+      modeData.reduce((sum, entry) => sum + entry.reactionMs, 0) / modeData.length
+    );
+    const averageDistance = Math.round(
+      modeData.reduce((sum, entry) => sum + entry.distancePx, 0) / modeData.length
+    );
+    return { averageScore, bestScore, averageReaction, averageDistance };
+  }, [modeData]);
 
   const renderItem = useCallback(
     ({ item, index }: { item: ScorePayload; index: number }) => {
@@ -270,6 +319,18 @@ export default function LeaderboardScreen() {
   const headerComponent = useMemo(
     () => (
       <View>
+        <View style={styles.topRow}>
+          <PlayerSwitcher style={styles.switcher} onPlayerChange={(player) => setActivePlayer(player)} />
+          <TouchableOpacity
+            style={[styles.chartToggle, showCharts && styles.chartToggleActive]}
+            onPress={() => setShowCharts((prev) => !prev)}
+            activeOpacity={0.85}
+          >
+            <Text style={[styles.chartToggleText, showCharts && styles.chartToggleTextActive]}>
+              {showCharts ? "Hide charts" : "Show charts"}
+            </Text>
+          </TouchableOpacity>
+        </View>
         <View style={styles.modeTabs}>
           {modes.map((mode) => {
             const isActive = activeMode === mode;
@@ -301,18 +362,40 @@ export default function LeaderboardScreen() {
             );
           })}
         </View>
-        <View style={styles.chartsWrapper}>
-          {metricConfigs.map((config) => (
-            <MetricChart key={config.key} data={modeData} {...config} />
-          ))}
-        </View>
+        {summary && (
+          <View style={styles.summaryRow}>
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>Avg score</Text>
+              <Text style={styles.summaryValue}>{summary.averageScore}</Text>
+            </View>
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>Best score</Text>
+              <Text style={styles.summaryValue}>{summary.bestScore}</Text>
+            </View>
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>Avg reaction</Text>
+              <Text style={styles.summaryValue}>{summary.averageReaction} ms</Text>
+            </View>
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>Avg miss</Text>
+              <Text style={styles.summaryValue}>{summary.averageDistance} px</Text>
+            </View>
+          </View>
+        )}
+        {showCharts && (
+          <View style={styles.chartsWrapper}>
+            {metricConfigs.map((config) => (
+              <MetricChart key={config.key} data={modeData} {...config} />
+            ))}
+          </View>
+        )}
         <View style={styles.sectionHeader}>
           <Text style={styles.sectionTitle}>Leaderboard</Text>
           {activePlayer && <Text style={styles.sectionSubtitle}>Active profile: {activePlayer.name}</Text>}
         </View>
       </View>
     ),
-    [activeMode, sortKey, modeData, modeCounts, activePlayer]
+    [activeMode, sortKey, modeData, modeCounts, activePlayer, showCharts, summary]
   );
 
   const emptyComponent = useMemo(
@@ -381,7 +464,43 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
   },
   sortChipTextActive: { color: palette.textPrimary },
+  topRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  switcher: { marginRight: 12 },
+  chartToggle: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: palette.border,
+    backgroundColor: palette.surfaceAlt,
+  },
+  chartToggleActive: { backgroundColor: palette.accent, borderColor: palette.accent },
+  chartToggleText: { color: palette.textSecondary, fontSize: 12, letterSpacing: 1 },
+  chartToggleTextActive: { color: palette.textPrimary },
   chartsWrapper: { marginBottom: 24 },
+  summaryRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    marginBottom: 18,
+  },
+  summaryCard: {
+    width: "48%",
+    backgroundColor: palette.surface,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: palette.border,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    marginBottom: 12,
+  },
+  summaryLabel: { color: palette.textSecondary, fontSize: 11, textTransform: "uppercase", letterSpacing: 1 },
+  summaryValue: { color: palette.textPrimary, fontSize: 16, fontWeight: "700", marginTop: 6 },
   chartCard: {
     backgroundColor: palette.surface,
     borderRadius: 16,
@@ -393,6 +512,10 @@ const styles = StyleSheet.create({
   chartHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
   chartTitle: { color: palette.textPrimary, fontSize: 16, fontWeight: "700" },
   chartMeta: { color: palette.textSecondary, fontSize: 12 },
+  chartTrend: { fontSize: 12, fontWeight: "600", color: palette.textSecondary },
+  chartTrendPositive: { color: palette.positive },
+  chartTrendNegative: { color: palette.negative },
+  chartTrendNeutral: { color: palette.textSecondary },
   chartBars: { flexDirection: "row", alignItems: "flex-end", height: 120, marginTop: 12 },
   chartBarTrack: {
     flex: 1,
@@ -408,6 +531,7 @@ const styles = StyleSheet.create({
     paddingBottom: 4,
   },
   chartBarFill: { width: "100%", borderRadius: 8 },
+  chartBarBest: { borderWidth: 1, borderColor: "rgba(255,255,255,0.35)" },
   chartFooter: { flexDirection: "row", justifyContent: "space-between", marginTop: 12 },
   chartFooterText: { color: palette.textSecondary, fontSize: 11 },
   chartCurrent: { color: palette.textSecondary, fontSize: 12, textAlign: "right", marginTop: 6 },

--- a/app/local.tsx
+++ b/app/local.tsx
@@ -1,0 +1,414 @@
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import { GameScreen, GameAttemptResult } from "../src/gameplay";
+import { MenuButton, PlayerSwitcher } from "../src/ui";
+import { palette } from "../src/theme";
+import { getPlayers, setActivePlayer } from "../src/storage";
+import type { GameMode, PlayerProfile } from "../src/types";
+
+const ROUNDS = 3;
+const TRIES_PER_ROUND = 5;
+
+const modeOptions: { key: GameMode; label: string; description: string }[] = [
+  { key: "SIMPLE", label: "Simple", description: "Static target" },
+  { key: "NORMAL", label: "Normal", description: "Horizontal motion" },
+  { key: "PRO", label: "Pro", description: "Full-field motion" },
+  { key: "EXTREME", label: "Extreme", description: "Dual targets" },
+];
+
+type TurnState = { round: number; shot: number; playerIndex: number };
+
+type SessionRecords = Record<string, GameAttemptResult[][]>;
+
+export default function LocalMultiplayerScreen() {
+  const [players, setPlayers] = useState<PlayerProfile[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [sessionMode, setSessionMode] = useState<GameMode>("NORMAL");
+  const [sessionPlayers, setSessionPlayers] = useState<PlayerProfile[]>([]);
+  const [sessionRecords, setSessionRecords] = useState<SessionRecords>({});
+  const [turn, setTurn] = useState<TurnState>({ round: 0, shot: 0, playerIndex: 0 });
+  const [sessionActive, setSessionActive] = useState(false);
+  const [sessionComplete, setSessionComplete] = useState(false);
+  const [awaitingAdvance, setAwaitingAdvance] = useState(false);
+  const [advanceLabel, setAdvanceLabel] = useState("Next attempt");
+  const nextTurnRef = useRef<TurnState | null>(null);
+
+  const loadPlayers = useCallback(async () => {
+    try {
+      const list = await getPlayers();
+      setPlayers(list);
+      if (!list.length) {
+        setSelectedIds([]);
+      }
+    } catch (error) {
+      console.warn("Failed to load players", error);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadPlayers();
+    }, [loadPlayers])
+  );
+
+  const togglePlayer = (playerId: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(playerId) ? prev.filter((id) => id !== playerId) : [...prev, playerId]
+    );
+  };
+
+  const selectedPlayers = useMemo(
+    () => players.filter((player) => selectedIds.includes(player.id)),
+    [players, selectedIds]
+  );
+
+  const createEmptyRecords = useCallback(
+    (participants: PlayerProfile[]): SessionRecords => {
+      return participants.reduce((acc, player) => {
+        acc[player.id] = Array.from({ length: ROUNDS }, () => [] as GameAttemptResult[]);
+        return acc;
+      }, {} as SessionRecords);
+    },
+    []
+  );
+
+  const standings = useMemo(() => {
+    if (!sessionPlayers.length) return [];
+    return sessionPlayers
+      .map((player) => {
+        const rounds = sessionRecords[player.id] ?? Array.from({ length: ROUNDS }, () => [] as GameAttemptResult[]);
+        const averages = rounds.map((attempts) =>
+          attempts.length
+            ? Math.round(attempts.reduce((sum, attempt) => sum + attempt.score, 0) / attempts.length)
+            : null
+        );
+        const total = averages.reduce((sum, value) => sum + (value ?? 0), 0);
+        return { player, rounds, averages, total };
+      })
+      .sort((a, b) => b.total - a.total);
+  }, [sessionPlayers, sessionRecords]);
+
+  const currentPlayer = sessionPlayers[turn.playerIndex];
+
+  const handleStartSession = useCallback(async () => {
+    const participants = selectedPlayers;
+    if (participants.length < 2) {
+      return;
+    }
+    setSessionPlayers(participants);
+    setSessionRecords(createEmptyRecords(participants));
+    setTurn({ round: 0, shot: 0, playerIndex: 0 });
+    setSessionComplete(false);
+    setSessionActive(true);
+    setAwaitingAdvance(false);
+    setAdvanceLabel("Next attempt");
+    try {
+      await setActivePlayer(participants[0].id);
+    } catch (error) {
+      console.warn("Unable to set active player", error);
+    }
+  }, [selectedPlayers, createEmptyRecords]);
+
+  const handleAttemptComplete = useCallback(
+    (attempt: GameAttemptResult) => {
+      const player = sessionPlayers[turn.playerIndex];
+      if (!player) return;
+
+      setSessionRecords((prev) => {
+        const next: SessionRecords = { ...prev };
+        const rounds = next[player.id]?.map((round) => [...round]) ?? Array.from({ length: ROUNDS }, () => [] as GameAttemptResult[]);
+        rounds[turn.round] = [...rounds[turn.round], attempt];
+        next[player.id] = rounds;
+        return next;
+      });
+
+      const nextShot = turn.shot + 1;
+      let nextRound = turn.round;
+      let nextPlayerIndex = turn.playerIndex;
+      let nextShotIndex = turn.shot;
+      let label = "Next attempt";
+      let complete = false;
+
+      if (nextShot >= TRIES_PER_ROUND) {
+        nextShotIndex = 0;
+        nextPlayerIndex += 1;
+        if (nextPlayerIndex >= sessionPlayers.length) {
+          nextPlayerIndex = 0;
+          nextRound += 1;
+          if (nextRound >= ROUNDS) {
+            complete = true;
+            label = "View results";
+          } else {
+            label = `Begin round ${nextRound + 1}`;
+          }
+        } else {
+          label = `Next player · ${sessionPlayers[nextPlayerIndex].name}`;
+        }
+      } else {
+        nextShotIndex = nextShot;
+        label = `Shot ${nextShot + 1}`;
+      }
+
+      if (complete) {
+        nextTurnRef.current = null;
+        setSessionComplete(true);
+      } else {
+        nextTurnRef.current = { round: nextRound, playerIndex: nextPlayerIndex, shot: nextShotIndex };
+      }
+
+      setAdvanceLabel(label);
+      setAwaitingAdvance(true);
+    },
+    [sessionPlayers, turn]
+  );
+
+  const handleAdvance = useCallback(
+    async (reset?: () => void) => {
+      if (!awaitingAdvance) return;
+      if (sessionComplete) {
+        setAwaitingAdvance(false);
+        setSessionActive(false);
+        return;
+      }
+      const nextTurn = nextTurnRef.current;
+      if (!nextTurn) return;
+      setTurn(nextTurn);
+      setAwaitingAdvance(false);
+      const nextPlayer = sessionPlayers[nextTurn.playerIndex];
+      if (nextPlayer) {
+        try {
+          await setActivePlayer(nextPlayer.id);
+        } catch (error) {
+          console.warn("Unable to set active player", error);
+        }
+      }
+      reset?.();
+    },
+    [awaitingAdvance, sessionComplete, sessionPlayers]
+  );
+
+  const turnLabel = sessionActive
+    ? `Round ${turn.round + 1}/${ROUNDS} · Shot ${turn.shot + 1}/${TRIES_PER_ROUND}`
+    : `Rounds: ${ROUNDS} · Shots per round: ${TRIES_PER_ROUND}`;
+
+  return (
+    <View style={styles.safe}>
+      {sessionActive ? (
+        <>
+          <ScrollView style={styles.sessionScroll} contentContainerStyle={styles.sessionContent}>
+            <View style={styles.header}>
+              <Text style={styles.title}>Local multiplayer</Text>
+              <PlayerSwitcher style={styles.headerSwitcher} />
+              <Text style={styles.subtitle}>{turnLabel}</Text>
+              {currentPlayer && (
+                <Text style={styles.currentPlayer}>{`Current shooter: ${currentPlayer.name}`}</Text>
+              )}
+            </View>
+            <View style={styles.standingsCard}>
+              <View style={styles.standingsHeader}>
+                <Text style={styles.standingsTitle}>Scoreboard</Text>
+              </View>
+              {standings.map((entry) => {
+                const isCurrent = sessionActive && currentPlayer && entry.player.id === currentPlayer.id;
+                return (
+                  <View key={entry.player.id} style={[styles.standingRow, isCurrent && styles.standingRowActive]}>
+                    <Text style={styles.standingName}>{entry.player.name}</Text>
+                    <View style={styles.standingRounds}>
+                      {entry.averages.map((avg, index) => (
+                        <Text
+                          key={`${entry.player.id}-round-${index}`}
+                          style={[styles.standingRoundValue, avg !== null ? styles.standingRoundValueFilled : styles.standingRoundValueEmpty]}
+                        >
+                          {avg !== null ? avg : "--"}
+                        </Text>
+                      ))}
+                    </View>
+                    <Text style={styles.standingTotal}>{entry.total}</Text>
+                  </View>
+                );
+              })}
+            </View>
+          </ScrollView>
+          <View style={styles.gameWrapper}>
+            <GameScreen
+              mode={sessionMode}
+              persistScore={false}
+              showPlayerSwitcher={false}
+              onAttemptComplete={handleAttemptComplete}
+              renderResultActions={({ reset }) => (
+                <MenuButton
+                  title={advanceLabel}
+                  onPress={() => handleAdvance(sessionComplete ? undefined : reset)}
+                  disabled={!awaitingAdvance}
+                />
+              )}
+            />
+          </View>
+        </>
+      ) : (
+        <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
+          <Text style={styles.title}>Local multiplayer</Text>
+          <PlayerSwitcher style={styles.selectionSwitcher} />
+          <Text style={styles.subtitle}>
+            Select at least two players and a mode. Each competitor shoots {TRIES_PER_ROUND} times per round for {ROUNDS}
+            rounds. Scores are averaged per round and summed to crown the champion.
+          </Text>
+          <View style={styles.section}> 
+            <Text style={styles.sectionTitle}>Players</Text>
+            {players.length ? (
+              players.map((player) => {
+                const isSelected = selectedIds.includes(player.id);
+                return (
+                  <TouchableOpacity
+                    key={player.id}
+                    style={[styles.playerOption, isSelected && styles.playerOptionSelected]}
+                    onPress={() => togglePlayer(player.id)}
+                    activeOpacity={0.85}
+                  >
+                    <Text style={styles.playerName}>{player.name}</Text>
+                    <Text style={styles.playerHint}>{isSelected ? "Tap to remove" : "Tap to add"}</Text>
+                  </TouchableOpacity>
+                );
+              })
+            ) : (
+              <Text style={styles.emptyMessage}>Create players from the main menu to start competing.</Text>
+            )}
+          </View>
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Game mode</Text>
+            <View style={styles.modeRow}>
+              {modeOptions.map((mode, index) => {
+                const isActive = sessionMode === mode.key;
+                return (
+                  <TouchableOpacity
+                    key={mode.key}
+                    style={[
+                      styles.modeChip,
+                      (index + 1) % 2 === 0 && styles.modeChipLast,
+                      isActive && styles.modeChipActive,
+                    ]}
+                    onPress={() => setSessionMode(mode.key)}
+                    activeOpacity={0.85}
+                  >
+                    <Text style={[styles.modeChipLabel, isActive && styles.modeChipLabelActive]}>{mode.label}</Text>
+                    <Text style={styles.modeChipHint}>{mode.description}</Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </View>
+          {sessionComplete && standings.length > 0 && (
+            <View style={styles.resultsBanner}>
+              <Text style={styles.resultsTitle}>Last winners</Text>
+              <Text style={styles.resultsText}>Champion: {standings[0].player.name}</Text>
+            </View>
+          )}
+          <MenuButton
+            title={selectedPlayers.length >= 2 ? "Start match" : "Pick at least two players"}
+            onPress={handleStartSession}
+            disabled={selectedPlayers.length < 2}
+            style={styles.startButton}
+          />
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: palette.background },
+  scroll: { flex: 1 },
+  sessionScroll: { flex: 1 },
+  content: { padding: 20, paddingBottom: 32 },
+  sessionContent: { padding: 20, paddingBottom: 24 },
+  title: { color: palette.textPrimary, fontSize: 26, fontWeight: "800", marginBottom: 12 },
+  subtitle: { color: palette.textSecondary, fontSize: 13, marginBottom: 16, lineHeight: 18 },
+  selectionSwitcher: { alignSelf: "flex-start", marginBottom: 12 },
+  header: { marginBottom: 16 },
+  headerSwitcher: { marginTop: 12, alignSelf: "flex-start" },
+  currentPlayer: { color: palette.textPrimary, fontSize: 14, marginTop: 8 },
+  section: { marginBottom: 24 },
+  sectionTitle: { color: palette.textPrimary, fontSize: 18, fontWeight: "700", marginBottom: 12 },
+  playerOption: {
+    backgroundColor: palette.surface,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 16,
+    marginBottom: 12,
+  },
+  playerOptionSelected: {
+    borderColor: palette.accent,
+    backgroundColor: palette.surfaceAlt,
+  },
+  playerName: { color: palette.textPrimary, fontSize: 16, fontWeight: "700" },
+  playerHint: { color: palette.textSecondary, fontSize: 12, marginTop: 4 },
+  emptyMessage: { color: palette.textSecondary, fontSize: 13, textAlign: "center", paddingVertical: 20 },
+  modeRow: { flexDirection: "row", flexWrap: "wrap" },
+  modeChip: {
+    width: "48%",
+    backgroundColor: palette.surface,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 12,
+    marginRight: "4%",
+    marginBottom: 12,
+  },
+  modeChipLast: { marginRight: 0 },
+  modeChipActive: { borderColor: palette.accent, backgroundColor: palette.surfaceAlt },
+  modeChipLabel: { color: palette.textSecondary, fontSize: 13, fontWeight: "700" },
+  modeChipLabelActive: { color: palette.textPrimary },
+  modeChipHint: { color: palette.textSecondary, fontSize: 11, marginTop: 6 },
+  startButton: { marginTop: 8 },
+  standingsCard: {
+    backgroundColor: palette.surface,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 16,
+    marginBottom: 20,
+  },
+  standingsHeader: { flexDirection: "row", justifyContent: "space-between", marginBottom: 12 },
+  standingsTitle: { color: palette.textPrimary, fontSize: 18, fontWeight: "700" },
+  standingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 12,
+    paddingBottom: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: palette.border,
+  },
+  standingRowActive: {
+    borderBottomWidth: 0,
+    backgroundColor: palette.surfaceAlt,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+  },
+  standingName: { color: palette.textPrimary, fontWeight: "700", flex: 1 },
+  standingRounds: { flexDirection: "row", marginRight: 12 },
+  standingRoundValue: {
+    width: 54,
+    textAlign: "center",
+    borderRadius: 10,
+    paddingVertical: 6,
+    marginLeft: 6,
+    fontSize: 13,
+  },
+  standingRoundValueFilled: { backgroundColor: palette.surfaceAlt, color: palette.textPrimary },
+  standingRoundValueEmpty: { backgroundColor: palette.surface, color: palette.textSecondary, borderWidth: 1, borderColor: palette.border },
+  standingTotal: { color: palette.textPrimary, fontSize: 16, fontWeight: "700", width: 48, textAlign: "right" },
+  resultsBanner: {
+    backgroundColor: palette.surfaceAlt,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 14,
+    marginBottom: 16,
+  },
+  resultsTitle: { color: palette.textPrimary, fontSize: 16, fontWeight: "700" },
+  resultsText: { color: palette.textSecondary, marginTop: 4 },
+  gameWrapper: { flex: 1, minHeight: 480 },
+});

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { View, StyleSheet, BackHandler, Text } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import { router } from "expo-router";
-import { MenuButton } from "../src/ui";
+import { MenuButton, PlayerSwitcher } from "../src/ui";
 import { palette } from "../src/theme";
-import { getActivePlayer } from "../src/storage";
+import { getActivePlayer, subscribeActivePlayer } from "../src/storage";
 import type { PlayerProfile } from "../src/types";
 
 export default function MainMenuScreen() {
@@ -25,10 +25,20 @@ export default function MainMenuScreen() {
 
   useFocusEffect(refreshActivePlayer);
 
+  useEffect(() => {
+    const unsubscribe = subscribeActivePlayer((player) => {
+      setActivePlayer(player);
+    });
+    return unsubscribe;
+  }, []);
+
   return (
     <View style={styles.safe}>
       <View style={styles.container}>
-        <Text style={styles.title}>Predict Aim</Text>
+        <View style={styles.titleRow}>
+          <Text style={styles.title}>Predict Aim</Text>
+          <PlayerSwitcher style={styles.switcher} onPlayerChange={(player) => setActivePlayer(player)} />
+        </View>
         <Text style={styles.subtitle}>Sharpen your prediction timing across dynamic targets.</Text>
         <View style={styles.playerCard}>
           <Text style={styles.playerCardLabel}>Active player</Text>
@@ -54,7 +64,9 @@ export default function MainMenuScreen() {
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: palette.background },
   container: { flex: 1, justifyContent: "center", padding: 24 },
-  title: { color: palette.textPrimary, fontSize: 30, fontWeight: "800" },
+  titleRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+  title: { color: palette.textPrimary, fontSize: 30, fontWeight: "800", flexShrink: 1, paddingRight: 12 },
+  switcher: { marginLeft: 12 },
   subtitle: { color: palette.textSecondary, fontSize: 14, marginTop: 8, marginBottom: 24 },
   playerCard: {
     backgroundColor: palette.surface,

--- a/src/gameplay.tsx
+++ b/src/gameplay.tsx
@@ -11,10 +11,10 @@ import {
   View,
 } from "react-native";
 import { calculateScore } from "./score";
-import { getActivePlayer, saveScoreEntry } from "./storage";
-import type { GameMode, ScorePayload } from "./types";
+import { getActivePlayer, saveScoreEntry, subscribeActivePlayer } from "./storage";
+import type { AttemptDetail, GameMode, ScorePayload } from "./types";
 import { palette } from "./theme";
-import { MenuButton } from "./ui";
+import { MenuButton, PlayerSwitcher } from "./ui";
 
 const TARGET_SIZE = 72;
 const TARGET_RADIUS = TARGET_SIZE / 2;
@@ -30,12 +30,20 @@ const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get("window");
 
 type Phase = "observe" | "countdown" | "guess" | "result";
 
-interface ResultState {
-  reactionMs: number;
-  distancePx: number;
-  score: number;
+interface ResultPair {
   target: { x: number; y: number };
   guess: { x: number; y: number };
+  distancePx: number;
+}
+
+export interface GameAttemptResult {
+  reactionMs: number;
+  score: number;
+  averageDistancePx: number;
+  pairs: ResultPair[];
+}
+
+interface ResultState extends GameAttemptResult {
   saveState: { status: "pending" | "saved" | "error"; message?: string };
 }
 
@@ -51,6 +59,10 @@ const modeDetails: Record<GameMode, { label: string; description: string }> = {
   PRO: {
     label: "Pro",
     description: "Free-flight motion in two dimensions. Track both axes to land the shot.",
+  },
+  EXTREME: {
+    label: "Extreme",
+    description: "Twin targets weave through the arena. Track and tag both before time runs out.",
   },
 };
 
@@ -68,6 +80,25 @@ const phaseCopy: Record<Exclude<Phase, "result">, { title: string; subtitle: str
     subtitle: "Tap where you believe the target is right now",
   },
 };
+
+const EXTREME_TARGET_COUNT = 2;
+
+const markerColorPairs = [
+  {
+    target: palette.positive,
+    targetBorder: "rgba(14,33,23,0.6)",
+    guess: palette.negative,
+    guessBorder: "rgba(48,14,18,0.6)",
+    label: "Target 1",
+  },
+  {
+    target: "#60A5FA",
+    targetBorder: "rgba(46,74,110,0.55)",
+    guess: "#FBBF24",
+    guessBorder: "rgba(120,82,14,0.55)",
+    label: "Target 2",
+  },
+];
 
 function randomBetween(min: number, max: number) {
   return Math.random() * (max - min) + min;
@@ -126,13 +157,20 @@ interface MotionController {
   stop: () => { x: number; y: number };
 }
 
-function useTargetMotion(mode: GameMode, width: number, height: number): MotionController {
+function useTargetMotion(
+  mode: GameMode,
+  width: number,
+  height: number,
+  options?: { seed?: number }
+): MotionController {
   const x = useRef(new Animated.Value(width / 2)).current;
   const y = useRef(new Animated.Value(height / 2)).current;
   const running = useRef(false);
   const animationRef = useRef<Animated.CompositeAnimation | null>(null);
   const positionRef = useRef({ x: width / 2, y: height / 2 });
   const velocityRef = useRef({ vx: 0, vy: 0 });
+  const seed = options?.seed ?? 0;
+  const baseMode = mode === "EXTREME" ? "PRO" : mode;
 
   useEffect(() => {
     const xListener = x.addListener(({ value }) => {
@@ -216,27 +254,31 @@ function useTargetMotion(mode: GameMode, width: number, height: number): MotionC
 
   const start = useCallback(() => {
     stop();
-    const startX = randomBetween(bounds.minX, bounds.maxX);
-    const startY = mode === "NORMAL" ? bounds.centerY : randomBetween(bounds.minY, bounds.maxY);
+    const offsetFactor = (Math.sin((seed + 1) * 1.618) + 1) / 2;
+    const jitterMagnitude = TARGET_RADIUS * 1.4;
+    const startXRaw = randomBetween(bounds.minX, bounds.maxX);
+    const startYRaw = baseMode === "NORMAL" ? bounds.centerY : randomBetween(bounds.minY, bounds.maxY);
+    const startX = clamp(startXRaw + (offsetFactor - 0.5) * jitterMagnitude, bounds.minX, bounds.maxX);
+    const startY = clamp(startYRaw + (offsetFactor - 0.5) * jitterMagnitude * 0.75, bounds.minY, bounds.maxY);
     x.setValue(startX);
     y.setValue(startY);
     positionRef.current = { x: startX, y: startY };
 
-    if (mode === "SIMPLE") {
+    if (baseMode === "SIMPLE") {
       return;
     }
 
-    if (mode === "NORMAL" && !bounds.canMoveX) {
+    if (baseMode === "NORMAL" && !bounds.canMoveX) {
       return;
     }
 
-    if (mode === "PRO" && !bounds.canMoveX && !bounds.canMoveY) {
+    if (baseMode === "PRO" && !bounds.canMoveX && !bounds.canMoveY) {
       return;
     }
 
     running.current = true;
 
-    if (mode === "NORMAL") {
+    if (baseMode === "NORMAL") {
       const midpoint = (bounds.minX + bounds.maxX) / 2;
       const travel = (nextX: number) => {
         if (!running.current) return;
@@ -260,15 +302,17 @@ function useTargetMotion(mode: GameMode, width: number, height: number): MotionC
       return;
     }
 
-    if (mode === "PRO") {
-      const baseSpeed = DIAGONAL_SPEED;
+    if (baseMode === "PRO") {
+      const speedBoost = mode === "EXTREME" ? 1.18 : 1;
+      const baseSpeed = DIAGONAL_SPEED * speedBoost;
       let vx = 0;
       let vy = 0;
 
       if (bounds.canMoveX && bounds.canMoveY) {
         const minimumComponent = 0.28;
         for (let attempt = 0; attempt < 8; attempt += 1) {
-          const angle = randomBetween(0, Math.PI * 2);
+          const angleOffset = (seed % 4) * Math.PI * 0.25;
+          const angle = randomBetween(0, Math.PI * 2) + angleOffset;
           const dirX = Math.cos(angle);
           const dirY = Math.sin(angle);
           if (Math.abs(dirX) < 1e-3 && Math.abs(dirY) < 1e-3) {
@@ -427,7 +471,7 @@ function useTargetMotion(mode: GameMode, width: number, height: number): MotionC
       travelWithBounces();
       return;
     }
-  }, [stop, bounds, mode, x, y]);
+  }, [stop, bounds, baseMode, mode, x, y, seed]);
 
   useEffect(() => stop, [stop]);
 
@@ -470,40 +514,110 @@ function ArcheryTarget() {
   );
 }
 
+
+type ResultActionRenderer = (args: {
+  reset: () => void;
+  exit?: () => void;
+  result: GameAttemptResult;
+}) => React.ReactNode;
+
 export interface GameScreenProps {
   mode: GameMode;
   onExit?: () => void;
+  persistScore?: boolean;
+  onAttemptComplete?: (result: GameAttemptResult) => void;
+  renderResultActions?: ResultActionRenderer;
+  showPlayerSwitcher?: boolean;
 }
 
-export function GameScreen({ mode, onExit }: GameScreenProps) {
+export function GameScreen({
+  mode,
+  onExit,
+  persistScore = true,
+  onAttemptComplete,
+  renderResultActions,
+  showPlayerSwitcher = true,
+}: GameScreenProps) {
+  const isExtreme = mode === "EXTREME";
   const [phase, setPhase] = useState<Phase>("observe");
   const [countdown, setCountdown] = useState(COUNTDOWN_STEPS);
   const [result, setResult] = useState<ResultState | null>(null);
   const [activePlayerName, setActivePlayerName] = useState<string | null>(null);
   const [fieldSize, setFieldSize] = useState<{ width: number; height: number } | null>(null);
   const [fieldOffset, setFieldOffset] = useState<{ x: number; y: number } | null>(null);
+  const [buttonsInteractive, setButtonsInteractive] = useState(false);
+  const [extremeProgress, setExtremeProgress] = useState(0);
+
   const fieldWidth = fieldSize?.width ?? SCREEN_W;
   const fieldHeight = fieldSize?.height ?? SCREEN_H;
   const isFieldReady = fieldSize !== null;
-  const { x, y, start, stop } = useTargetMotion(mode, fieldWidth, fieldHeight);
+
+  const {
+    x: primaryX,
+    y: primaryY,
+    start: startPrimary,
+    stop: stopPrimary,
+  } = useTargetMotion(mode, fieldWidth, fieldHeight, { seed: 1 });
+  const {
+    x: secondaryX,
+    y: secondaryY,
+    start: startSecondary,
+    stop: stopSecondary,
+  } = useTargetMotion("EXTREME", fieldWidth, fieldHeight, { seed: 7 });
+
   const startRef = useRef(0);
   const fieldRef = useRef<View>(null);
   const lastTouchRef = useRef<{ x: number; y: number } | null>(null);
+  const targetSnapshotsRef = useRef<{ x: number; y: number }[] | null>(null);
+  const guessesRef = useRef<{ x: number; y: number }[]>([]);
   const resultAnims = useRef([new Animated.Value(0), new Animated.Value(0), new Animated.Value(0)]).current;
   const resultButtonsOpacity = useRef(new Animated.Value(0)).current;
-  const [buttonsInteractive, setButtonsInteractive] = useState(false);
   const shake = useRef(new Animated.Value(0)).current;
 
-  const targetStyle = useMemo(
+  const primaryTargetStyle = useMemo(
     () => ({
       transform: [
-        { translateX: Animated.subtract(x, TARGET_RADIUS) },
-        { translateY: Animated.subtract(y, TARGET_RADIUS) },
+        { translateX: Animated.subtract(primaryX, TARGET_RADIUS) },
+        { translateY: Animated.subtract(primaryY, TARGET_RADIUS) },
       ],
       opacity: isFieldReady ? 1 : 0,
     }),
-    [x, y, isFieldReady]
+    [primaryX, primaryY, isFieldReady]
   );
+
+  const secondaryTargetStyle = useMemo(
+    () => ({
+      transform: [
+        { translateX: Animated.subtract(secondaryX, TARGET_RADIUS) },
+        { translateY: Animated.subtract(secondaryY, TARGET_RADIUS) },
+      ],
+      opacity: isExtreme && isFieldReady ? 1 : 0,
+    }),
+    [secondaryX, secondaryY, isExtreme, isFieldReady]
+  );
+
+  const shakeStyle = useMemo(
+    () => ({
+      transform: [
+        {
+          translateX: shake.interpolate({ inputRange: [-1, 1], outputRange: [-10, 10] }),
+        },
+        {
+          translateY: shake.interpolate({ inputRange: [-1, 1], outputRange: [-6, 6] }),
+        },
+      ],
+    }),
+    [shake]
+  );
+
+  useEffect(() => {
+    const unsubscribe = subscribeActivePlayer((player) => {
+      setActivePlayerName(player?.name ?? null);
+    });
+    return unsubscribe;
+  }, []);
+
+  const detail = modeDetails[mode];
 
   const handleFieldLayout = useCallback((evt: LayoutChangeEvent) => {
     const { width, height } = evt.nativeEvent.layout;
@@ -541,41 +655,30 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
     [phase, isFieldReady, fieldOffset, fieldWidth, fieldHeight]
   );
 
-  const shakeStyle = useMemo(
-    () => ({
-      transform: [
-        {
-          translateX: shake.interpolate({ inputRange: [-1, 1], outputRange: [-10, 10] }),
-        },
-        {
-          translateY: shake.interpolate({ inputRange: [-1, 1], outputRange: [-6, 6] }),
-        },
-      ],
-    }),
-    [shake]
-  );
+  const startTargets = useCallback(() => {
+    startPrimary();
+    if (isExtreme) {
+      startSecondary();
+    }
+  }, [startPrimary, startSecondary, isExtreme]);
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const active = await getActivePlayer();
-      if (!cancelled) {
-        setActivePlayerName(active?.name ?? null);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const stopTargets = useCallback(() => {
+    const primary = stopPrimary();
+    if (isExtreme) {
+      const secondary = stopSecondary();
+      return [primary, secondary];
+    }
+    return [primary];
+  }, [stopPrimary, stopSecondary, isExtreme]);
 
   useEffect(() => {
     if (phase !== "observe" || !isFieldReady) return;
-    start();
+    startTargets();
     const timer = setTimeout(() => {
       setPhase("countdown");
     }, OBSERVE_DURATION);
     return () => clearTimeout(timer);
-  }, [phase, start, isFieldReady]);
+  }, [phase, isFieldReady, startTargets]);
 
   useEffect(() => {
     if (phase !== "countdown") return;
@@ -648,6 +751,7 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
   }, [phase, result, resultButtonsOpacity]);
 
   useEffect(() => {
+    if (!persistScore) return;
     if (phase !== "result" || !result || result.saveState.status !== "pending") return;
     if (fieldWidth <= 0 || fieldHeight <= 0) return;
     let cancelled = false;
@@ -657,20 +761,29 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
         if (!cancelled) {
           setActivePlayerName(activePlayer?.name ?? null);
         }
+        const attempts: AttemptDetail[] = result.pairs.map((pair) => ({
+          targetX: pair.target.x,
+          targetY: pair.target.y,
+          guessX: pair.guess.x,
+          guessY: pair.guess.y,
+          distancePx: pair.distancePx,
+        }));
+        const primaryPair = attempts[0];
         const payload: ScorePayload = {
           nickname: activePlayer?.name ?? "anon",
           playerId: activePlayer?.id ?? null,
           mode,
-          distancePx: result.distancePx,
+          distancePx: result.averageDistancePx,
           reactionMs: result.reactionMs,
           screenWidth: fieldWidth,
           screenHeight: fieldHeight,
-          targetX: result.target.x,
-          targetY: result.target.y,
-          guessX: result.guess.x,
-          guessY: result.guess.y,
+          targetX: primaryPair?.targetX ?? 0,
+          targetY: primaryPair?.targetY ?? 0,
+          guessX: primaryPair?.guessX ?? 0,
+          guessY: primaryPair?.guessY ?? 0,
           timestamp: new Date().toISOString(),
           score: result.score,
+          attempts,
         };
         await saveScoreEntry(payload);
         if (!cancelled) {
@@ -702,7 +815,7 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
     return () => {
       cancelled = true;
     };
-  }, [phase, result, mode, fieldWidth, fieldHeight]);
+  }, [phase, result, persistScore, mode, fieldWidth, fieldHeight]);
 
   const handleGuess = useCallback(
     (evt: GestureResponderEvent) => {
@@ -718,9 +831,7 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
         !!fallbackTouch &&
         (!Number.isFinite(guessX) ||
           !Number.isFinite(guessY) ||
-          (guessX === 0 &&
-            guessY === 0 &&
-            (fallbackTouch.x !== 0 || fallbackTouch.y !== 0)));
+          (guessX === 0 && guessY === 0 && (fallbackTouch.x !== 0 || fallbackTouch.y !== 0)));
 
       if (shouldUseFallback) {
         guessX = fallbackTouch.x;
@@ -739,31 +850,78 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
         y: clamp(guessY - 25, 0, fieldHeight),
       };
       lastTouchRef.current = null;
-      const target = stop();
-      const reactionMs = Date.now() - startRef.current;
-      const distancePx = Math.hypot(guess.x - target.x, guess.y - target.y);
-      const maxDistance = Math.max(1, Math.hypot(fieldWidth, fieldHeight));
-      const score = calculateScore(distancePx, reactionMs, maxDistance);
-      setResult({
-        reactionMs,
-        distancePx,
-        score,
-        target,
-        guess,
-        saveState: { status: "pending" },
+
+      if (!targetSnapshotsRef.current) {
+        targetSnapshotsRef.current = stopTargets();
+      }
+
+      guessesRef.current = [...guessesRef.current, guess];
+      const requiredShots = isExtreme ? EXTREME_TARGET_COUNT : 1;
+      const shotsTaken = guessesRef.current.length;
+
+      if (isExtreme && shotsTaken < requiredShots) {
+        setExtremeProgress(shotsTaken);
+        return;
+      }
+
+      const snapshots = targetSnapshotsRef.current ?? stopTargets();
+      const pairs: ResultPair[] = snapshots.map((target, index) => {
+        const shot = guessesRef.current[index] ?? guessesRef.current[guessesRef.current.length - 1];
+        return {
+          target,
+          guess: shot,
+          distancePx: Math.hypot(shot.x - target.x, shot.y - target.y),
+        };
       });
+
+      const averageDistance =
+        pairs.length > 0
+          ? pairs.reduce((sum, pair) => sum + pair.distancePx, 0) / pairs.length
+          : 0;
+
+      const reactionMs = Date.now() - startRef.current;
+      const maxDistance = Math.max(1, Math.hypot(fieldWidth, fieldHeight));
+      const score = calculateScore(averageDistance, reactionMs, maxDistance);
+
+      const attempt: GameAttemptResult = {
+        reactionMs,
+        score,
+        averageDistancePx: averageDistance,
+        pairs,
+      };
+
+      const saveState = persistScore
+        ? { status: "pending" as const }
+        : { status: "saved" as const, message: "Session only – not saved" };
+
+      setResult({ ...attempt, saveState });
       setPhase("result");
+      guessesRef.current = [];
+      targetSnapshotsRef.current = null;
+      setExtremeProgress(0);
+      onAttemptComplete?.(attempt);
     },
-    [phase, stop, isFieldReady, fieldWidth, fieldHeight, fieldOffset]
+    [
+      phase,
+      isFieldReady,
+      fieldOffset,
+      fieldWidth,
+      fieldHeight,
+      stopTargets,
+      persistScore,
+      onAttemptComplete,
+      isExtreme,
+    ]
   );
 
   const resetGame = useCallback(() => {
     setResult(null);
     setCountdown(COUNTDOWN_STEPS);
     setPhase("observe");
+    setExtremeProgress(0);
+    targetSnapshotsRef.current = null;
+    guessesRef.current = [];
   }, []);
-
-  const detail = modeDetails[mode];
 
   const resultItems = result
     ? [
@@ -775,8 +933,8 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
         },
         {
           key: "distance",
-          label: "Distance",
-          value: `${Math.round(result.distancePx)} px`,
+          label: result.pairs.length > 1 ? "Avg distance" : "Distance",
+          value: `${Math.round(result.averageDistancePx)} px`,
           style: styles.resultSmall,
         },
         {
@@ -788,11 +946,38 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
       ]
     : [];
 
+  const guessPrompt = isExtreme
+    ? `Shot ${Math.min(extremeProgress + 1, EXTREME_TARGET_COUNT)} of ${EXTREME_TARGET_COUNT}`
+    : "Tap now";
+
+  const guessSubtitle = isExtreme
+    ? extremeProgress === 0
+      ? "Tag the first hidden target"
+      : "Lock in the second target"
+    : phaseCopy.guess.subtitle;
+
+  const renderedActions =
+    result && renderResultActions
+      ? renderResultActions({ reset: resetGame, exit: onExit, result })
+      : (
+          <>
+            <MenuButton title="Play again" onPress={resetGame} style={styles.inlineButton} />
+            {onExit && <MenuButton title="Back to modes" onPress={onExit} style={styles.inlineButton} />}
+          </>
+        );
+
   return (
     <View style={styles.safe}>
       <View style={styles.header}>
-        <Text style={styles.modeTitle}>{detail.label} Mode</Text>
-        <Text style={styles.modeSubtitle}>{detail.description}</Text>
+        <View style={styles.headerRow}>
+          <View style={styles.titleGroup}>
+            <Text style={styles.modeTitle}>{detail.label} Mode</Text>
+            <Text style={styles.modeSubtitle}>{detail.description}</Text>
+          </View>
+          {showPlayerSwitcher && (
+            <PlayerSwitcher style={styles.switcher} onPlayerChange={(player) => setActivePlayerName(player?.name ?? null)} />
+          )}
+        </View>
         <Text style={styles.playerBadge}>
           {activePlayerName ? `Active player · ${activePlayerName}` : "No active player selected"}
         </Text>
@@ -806,31 +991,47 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
           disabled={phase !== "guess" || !isFieldReady}
           onPress={handleGuess}
         >
-          <Animated.View style={[styles.target, targetStyle]}>
+          <Animated.View style={[styles.target, primaryTargetStyle]}>
             <ArcheryTarget />
           </Animated.View>
+          {isExtreme && (
+            <Animated.View style={[styles.target, styles.secondaryTarget, secondaryTargetStyle]}>
+              <ArcheryTarget />
+            </Animated.View>
+          )}
           {phase === "result" && result && (
             <>
-              <View
-                style={[
-                  styles.marker,
-                  styles.markerTarget,
-                  {
-                    left: result.target.x - MARKER_SIZE / 2,
-                    top: result.target.y - MARKER_SIZE / 2,
-                  },
-                ]}
-              />
-              <View
-                style={[
-                  styles.marker,
-                  styles.markerGuess,
-                  {
-                    left: result.guess.x - MARKER_SIZE / 2,
-                    top: result.guess.y - MARKER_SIZE / 2,
-                  },
-                ]}
-              />
+              {result.pairs.map((pair, index) => {
+                const paletteEntry = markerColorPairs[index % markerColorPairs.length];
+                return (
+                  <React.Fragment key={`marker-${index}`}>
+                    <View
+                      style={[
+                        styles.marker,
+                        styles.markerTarget,
+                        {
+                          left: pair.target.x - MARKER_SIZE / 2,
+                          top: pair.target.y - MARKER_SIZE / 2,
+                          backgroundColor: paletteEntry.target,
+                          borderColor: paletteEntry.targetBorder,
+                        },
+                      ]}
+                    />
+                    <View
+                      style={[
+                        styles.marker,
+                        styles.markerGuess,
+                        {
+                          left: pair.guess.x - MARKER_SIZE / 2,
+                          top: pair.guess.y - MARKER_SIZE / 2,
+                          backgroundColor: paletteEntry.guess,
+                          borderColor: paletteEntry.guessBorder,
+                        },
+                      ]}
+                    />
+                  </React.Fragment>
+                );
+              })}
             </>
           )}
           {(phase === "countdown" || phase === "guess") && (
@@ -838,13 +1039,15 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
               style={[styles.overlay, phase === "guess" ? styles.overlayGuess : styles.overlayCountdown]}
               pointerEvents="none"
             >
-              <Text style={styles.overlayTitle}>{phaseCopy[phase].title}</Text>
+              <Text style={styles.overlayTitle}>
+                {phase === "guess" && isExtreme ? "Take the shots" : phaseCopy[phase].title}
+              </Text>
               {phase === "countdown" ? (
                 <Text style={styles.countdown}>{countdown}</Text>
               ) : (
-                <Text style={styles.guessText}>Tap now</Text>
+                <Text style={styles.guessText}>{guessPrompt}</Text>
               )}
-              <Text style={styles.overlaySubtitle}>{phaseCopy[phase].subtitle}</Text>
+              <Text style={styles.overlaySubtitle}>{phase === "guess" ? guessSubtitle : phaseCopy[phase].subtitle}</Text>
             </View>
           )}
           {phase === "result" && result && (
@@ -876,11 +1079,27 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
                     </Animated.View>
                   ))}
                 </View>
+                {result.pairs.length > 1 && (
+                  <View style={styles.pairsBreakdown}>
+                    {result.pairs.map((pair, index) => (
+                      <Text key={`pair-${index}`} style={styles.pairDistance}>
+                        {`Target ${index + 1}: ${Math.round(pair.distancePx)} px miss`}
+                      </Text>
+                    ))}
+                  </View>
+                )}
                 <View style={styles.legendRow}>
-                  <View style={[styles.legendDot, { backgroundColor: palette.positive }]} />
-                  <Text style={styles.legendText}>Actual target</Text>
-                  <View style={[styles.legendDot, { backgroundColor: palette.negative, marginLeft: 16 }]} />
-                  <Text style={styles.legendText}>Your guess</Text>
+                  {result.pairs.map((_, index) => {
+                    const paletteEntry = markerColorPairs[index % markerColorPairs.length];
+                    return (
+                      <View key={`legend-${index}`} style={styles.legendGroup}>
+                        <View style={[styles.legendDot, { backgroundColor: paletteEntry.target }]} />
+                        <Text style={styles.legendText}>{`Target ${index + 1}`}</Text>
+                        <View style={[styles.legendDot, { backgroundColor: paletteEntry.guess, marginLeft: 12 }]} />
+                        <Text style={styles.legendText}>{`Shot ${index + 1}`}</Text>
+                      </View>
+                    );
+                  })}
                 </View>
                 {result.saveState.status !== "pending" && (
                   <Text
@@ -909,10 +1128,7 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
                   ]}
                   pointerEvents={buttonsInteractive ? "auto" : "none"}
                 >
-                  <MenuButton title="Play again" onPress={resetGame} style={styles.inlineButton} />
-                  {onExit && (
-                    <MenuButton title="Back to modes" onPress={onExit} style={styles.inlineButton} />
-                  )}
+                  {renderedActions}
                 </Animated.View>
               </View>
             </View>
@@ -924,62 +1140,36 @@ export function GameScreen({ mode, onExit }: GameScreenProps) {
 }
 
 const styles = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: palette.background,
-    padding: 20,
-  },
-  header: {
-    paddingVertical: 8,
-  },
-  modeTitle: {
-    color: palette.textPrimary,
-    fontSize: 24,
-    fontWeight: "700",
-  },
-  modeSubtitle: {
-    color: palette.textSecondary,
-    fontSize: 14,
-    marginTop: 4,
-  },
+  safe: { flex: 1, backgroundColor: palette.background },
+  header: { paddingHorizontal: 20, paddingTop: 24, paddingBottom: 10 },
+  headerRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
+  titleGroup: { flexShrink: 1, paddingRight: 12 },
+  modeTitle: { color: palette.textPrimary, fontSize: 24, fontWeight: "800" },
+  modeSubtitle: { color: palette.textSecondary, fontSize: 13, marginTop: 4 },
+  switcher: { marginTop: -6 },
   playerBadge: {
-    marginTop: 12,
-    alignSelf: "flex-start",
-    paddingVertical: 4,
-    paddingHorizontal: 12,
-    borderRadius: 999,
-    backgroundColor: palette.surfaceAlt,
-    borderWidth: 1,
-    borderColor: palette.border,
     color: palette.textSecondary,
     fontSize: 12,
-    letterSpacing: 0.6,
+    marginTop: 12,
     textTransform: "uppercase",
+    letterSpacing: 1,
   },
-  fieldWrapper: {
+  fieldWrapper: { flex: 1, paddingHorizontal: 12, paddingBottom: 20 },
+  field: {
     flex: 1,
-    marginTop: 16,
-    borderRadius: 20,
+    borderRadius: 24,
+    backgroundColor: palette.surface,
     borderWidth: 1,
     borderColor: palette.border,
     overflow: "hidden",
-    backgroundColor: palette.surface,
-    shadowColor: "#020806",
-    shadowOpacity: 0.45,
-    shadowOffset: { width: 0, height: 12 },
-    shadowRadius: 20,
-    elevation: 10,
-  },
-  field: {
-    flex: 1,
   },
   target: {
     position: "absolute",
     width: TARGET_SIZE,
     height: TARGET_SIZE,
     borderRadius: TARGET_RADIUS,
-    alignItems: "center",
     justifyContent: "center",
+    alignItems: "center",
   },
   targetFace: {
     width: TARGET_SIZE,
@@ -988,6 +1178,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
+  secondaryTarget: { opacity: 0.75 },
   marker: {
     position: "absolute",
     width: MARKER_SIZE,
@@ -995,12 +1186,10 @@ const styles = StyleSheet.create({
     borderRadius: MARKER_SIZE / 2,
   },
   markerTarget: {
-    backgroundColor: palette.positive,
     borderWidth: 2,
     borderColor: "rgba(14,33,23,0.6)",
   },
   markerGuess: {
-    backgroundColor: palette.negative,
     borderWidth: 2,
     borderColor: "rgba(48,14,18,0.6)",
   },
@@ -1034,7 +1223,7 @@ const styles = StyleSheet.create({
   },
   guessText: {
     color: palette.textPrimary,
-    fontSize: 40,
+    fontSize: 36,
     fontWeight: "800",
     marginVertical: 18,
   },
@@ -1047,7 +1236,7 @@ const styles = StyleSheet.create({
   },
   resultsCard: {
     width: "100%",
-    maxWidth: 360,
+    maxWidth: 380,
     backgroundColor: palette.surfaceAltOpacity,
     borderRadius: 18,
     padding: 20,
@@ -1084,10 +1273,27 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginTop: 4,
   },
+  pairsBreakdown: {
+    marginTop: 8,
+    marginBottom: 4,
+  },
+  pairDistance: {
+    color: palette.textSecondary,
+    fontSize: 12,
+    textAlign: "center",
+    marginTop: 4,
+  },
   legendRow: {
     flexDirection: "row",
+    flexWrap: "wrap",
     alignItems: "center",
     marginTop: 12,
+  },
+  legendGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginRight: 18,
+    marginTop: 6,
   },
   legendDot: {
     width: 10,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -6,6 +6,20 @@ const KEY_PLAYERS = "players";
 const KEY_ACTIVE_PLAYER = "activePlayer";
 const KEY_SCORES = "scores";
 
+type ActivePlayerListener = (player: PlayerProfile | null) => void;
+
+const activePlayerListeners = new Set<ActivePlayerListener>();
+
+function emitActivePlayerChange(player: PlayerProfile | null) {
+  activePlayerListeners.forEach((listener) => {
+    try {
+      listener(player);
+    } catch (error) {
+      console.warn("Active player listener failed", error);
+    }
+  });
+}
+
 function sanitizeName(name: string) {
   return name.trim();
 }
@@ -90,6 +104,7 @@ export async function setActivePlayer(playerId: string) {
   }
   await AsyncStorage.setItem(KEY_ACTIVE_PLAYER, target.id);
   await AsyncStorage.setItem(KEY_NICKNAME, target.name);
+  emitActivePlayerChange(target);
 }
 
 export async function getActivePlayer(): Promise<PlayerProfile | null> {
@@ -106,6 +121,27 @@ export async function getActivePlayer(): Promise<PlayerProfile | null> {
   await AsyncStorage.setItem(KEY_ACTIVE_PLAYER, fallback.id);
   await AsyncStorage.setItem(KEY_NICKNAME, fallback.name);
   return fallback;
+}
+
+export function subscribeActivePlayer(listener: ActivePlayerListener) {
+  activePlayerListeners.add(listener);
+  let cancelled = false;
+  (async () => {
+    try {
+      const player = await getActivePlayer();
+      if (!cancelled) {
+        listener(player);
+      }
+    } catch {
+      if (!cancelled) {
+        listener(null);
+      }
+    }
+  })();
+  return () => {
+    cancelled = true;
+    activePlayerListeners.delete(listener);
+  };
 }
 
 export async function saveNickname(name: string) {
@@ -136,6 +172,15 @@ export async function saveScoreEntry(entry: ScorePayload) {
     ...entry,
     nickname: sanitizeName(entry.nickname),
     playerId: entry.playerId ?? null,
+    attempts: entry.attempts
+      ? entry.attempts.map((attempt) => ({
+          targetX: attempt.targetX,
+          targetY: attempt.targetY,
+          guessX: attempt.guessX,
+          guessY: attempt.guessY,
+          distancePx: attempt.distancePx,
+        }))
+      : undefined,
   };
   const updated = [...existing, sanitized].sort((a, b) => b.score - a.score);
   await AsyncStorage.setItem(KEY_SCORES, JSON.stringify(updated));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,12 @@
-export type GameMode = "SIMPLE" | "NORMAL" | "PRO";
+export type GameMode = "SIMPLE" | "NORMAL" | "PRO" | "EXTREME";
+
+export interface AttemptDetail {
+  targetX: number;
+  targetY: number;
+  guessX: number;
+  guessY: number;
+  distancePx: number;
+}
 
 export interface PlayerProfile {
   id: string;
@@ -20,4 +28,5 @@ export interface ScorePayload {
   timestamp: string;
   score: number;
   playerId?: string | null;
+  attempts?: AttemptDetail[];
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,6 +1,132 @@
-import React from "react";
-import { TouchableOpacity, Text, StyleSheet, ViewStyle } from "react-native";
+import React, { useCallback, useMemo, useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View, ViewStyle } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import { router } from "expo-router";
 import { palette } from "./theme";
+import { getPlayers, setActivePlayer, subscribeActivePlayer } from "./storage";
+import type { PlayerProfile } from "./types";
+
+export function PlayerSwitcher({
+  style,
+  onPlayerChange,
+}: {
+  style?: ViewStyle;
+  onPlayerChange?: (player: PlayerProfile | null) => void;
+}) {
+  const [players, setPlayers] = useState<PlayerProfile[]>([]);
+  const [activePlayer, setActivePlayerState] = useState<PlayerProfile | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const loadPlayers = useCallback(async () => {
+    try {
+      const list = await getPlayers();
+      setPlayers(list);
+    } catch (error) {
+      console.warn("Unable to load players", error);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadPlayers();
+      return () => {
+        setExpanded(false);
+      };
+    }, [loadPlayers])
+  );
+
+  React.useEffect(() => {
+    const unsubscribe = subscribeActivePlayer((player) => {
+      setActivePlayerState(player);
+      onPlayerChange?.(player);
+    });
+    return unsubscribe;
+  }, [onPlayerChange]);
+
+  const hasPlayers = players.length > 0;
+  const inactivePlayers = useMemo(
+    () => players.filter((player) => player.id !== activePlayer?.id),
+    [players, activePlayer?.id]
+  );
+
+  const handleSelect = useCallback(
+    async (playerId: string) => {
+      try {
+        await setActivePlayer(playerId);
+        await loadPlayers();
+      } catch (error) {
+        console.warn("Unable to switch active player", error);
+      } finally {
+        setExpanded(false);
+      }
+    },
+    [loadPlayers]
+  );
+
+  const triggerLabel = activePlayer?.name ?? (hasPlayers ? "Select player" : "Add a player");
+  const helperText = hasPlayers
+    ? "Switch active player"
+    : "No players yet · Tap to manage";
+
+  return (
+    <View style={[styles.switcherContainer, style]}>
+      <TouchableOpacity
+        style={[styles.switcherTrigger, expanded && styles.switcherTriggerActive]}
+        onPress={() => {
+          if (!hasPlayers) {
+            router.push("/players");
+            return;
+          }
+          setExpanded((prev) => !prev);
+        }}
+        activeOpacity={0.85}
+      >
+        <View>
+          <Text style={styles.switcherLabel}>{triggerLabel}</Text>
+          <Text style={styles.switcherHint}>{helperText}</Text>
+        </View>
+        <Text style={styles.switcherCaret}>{expanded ? "▲" : "▼"}</Text>
+      </TouchableOpacity>
+      {expanded && (
+        <View style={styles.switcherDropdown}>
+          <Text style={styles.switcherDropdownTitle}>Active player</Text>
+          <TouchableOpacity
+            style={[styles.switcherItem, styles.switcherItemActive]}
+            onPress={() => setExpanded(false)}
+            activeOpacity={0.85}
+          >
+            <Text style={styles.switcherItemName}>{activePlayer?.name ?? "None selected"}</Text>
+            <Text style={styles.switcherItemMeta}>
+              {activePlayer ? "Currently tracking scores" : "Scores won't save until one is active"}
+            </Text>
+          </TouchableOpacity>
+          {inactivePlayers.map((player) => (
+            <TouchableOpacity
+              key={player.id}
+              style={styles.switcherItem}
+              onPress={() => handleSelect(player.id)}
+              activeOpacity={0.85}
+            >
+              <Text style={styles.switcherItemName}>{player.name}</Text>
+              <Text style={styles.switcherItemMeta}>Set active profile</Text>
+            </TouchableOpacity>
+          ))}
+          <TouchableOpacity
+            style={styles.switcherManage}
+            onPress={() => {
+              setExpanded(false);
+              router.push("/players");
+            }}
+            activeOpacity={0.85}
+          >
+            <Text style={styles.switcherManageText}>Manage players</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
 export function MenuButton({
   title,
   onPress,
@@ -23,6 +149,7 @@ export function MenuButton({
     </TouchableOpacity>
   );
 }
+
 const styles = StyleSheet.create({
   btn: {
     paddingVertical: 14,
@@ -43,4 +170,96 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   btnText: { color: palette.textPrimary, fontSize: 16, fontWeight: "700" },
+  switcherContainer: {
+    position: "relative",
+  },
+  switcherTrigger: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: palette.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: palette.border,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    minWidth: 180,
+  },
+  switcherTriggerActive: {
+    borderColor: palette.accent,
+  },
+  switcherLabel: {
+    color: palette.textPrimary,
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  switcherHint: {
+    color: palette.textSecondary,
+    fontSize: 11,
+    marginTop: 2,
+  },
+  switcherCaret: {
+    color: palette.textSecondary,
+    fontSize: 12,
+    marginLeft: 12,
+  },
+  switcherDropdown: {
+    position: "absolute",
+    top: "100%",
+    left: 0,
+    right: 0,
+    backgroundColor: palette.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 12,
+    marginTop: 8,
+    shadowColor: "#04060A",
+    shadowOpacity: 0.25,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 6,
+    zIndex: 20,
+  },
+  switcherDropdownTitle: {
+    color: palette.textSecondary,
+    fontSize: 12,
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    marginBottom: 8,
+  },
+  switcherItem: {
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: palette.border,
+    marginBottom: 8,
+    backgroundColor: palette.surfaceAlt,
+  },
+  switcherItemActive: {
+    borderColor: palette.accent,
+    backgroundColor: palette.surfaceAlt,
+  },
+  switcherItemName: {
+    color: palette.textPrimary,
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  switcherItemMeta: {
+    color: palette.textSecondary,
+    fontSize: 11,
+    marginTop: 2,
+  },
+  switcherManage: {
+    paddingVertical: 10,
+    alignItems: "center",
+    borderRadius: 10,
+    backgroundColor: palette.surfaceAlt,
+  },
+  switcherManageText: {
+    color: palette.accent,
+    fontWeight: "700",
+    fontSize: 13,
+  },
 });


### PR DESCRIPTION
## Summary
- expose the PlayerSwitcher from more screens so swapping competitors is fast everywhere
- add an Extreme mode with dual-target gameplay and wire it into routing, storage, and scoring
- build a three-round local multiplayer session flow with per-round averages and advancement controls
- refresh the leaderboard with chart toggles, summary cards, and richer trend insights

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf016caca48330be857d166ae403a6