### PR TITLE
Limit player switching to solo results and expand multiplayer recap

### DIFF
--- a/app/gamemodes.tsx
+++ b/app/gamemodes.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { View, StyleSheet, Text } from "react-native";
+import { View, StyleSheet, Text, TouchableOpacity } from "react-native";
 import { router } from "expo-router";
-import { MenuButton, PlayerSwitcher } from "../src/ui";
+import { MenuButton } from "../src/ui";
 import { palette } from "../src/theme";
 
 const modes = [
@@ -39,10 +39,10 @@ export default function GamemodeScreen() {
   return (
     <View style={styles.safe}>
       <View style={styles.container}>
-        <View style={styles.titleRow}>
-          <Text style={styles.title}>Choose your challenge</Text>
-          <PlayerSwitcher style={styles.switcher} />
-        </View>
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()} activeOpacity={0.85}>
+          <Text style={styles.backText}>Back to menu</Text>
+        </TouchableOpacity>
+        <Text style={styles.title}>Choose your challenge</Text>
         {modes.map((mode) => (
           <View key={mode.title} style={styles.option}>
             <MenuButton title={mode.title} onPress={() => router.push(mode.path)} style={styles.optionButton} />
@@ -64,13 +64,14 @@ export default function GamemodeScreen() {
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: palette.background },
   container: { flex: 1, justifyContent: "center", padding: 24 },
-  titleRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 12 },
+  backButton: { alignSelf: "flex-start", paddingVertical: 6, paddingHorizontal: 2, marginBottom: 12 },
+  backText: { color: palette.textSecondary, fontSize: 13 },
   title: {
     color: palette.textPrimary,
-    fontSize: 24,
-    fontWeight: "700",
+    fontSize: 26,
+    fontWeight: "800",
+    marginBottom: 12,
   },
-  switcher: { marginLeft: 16 },
   option: {
     backgroundColor: palette.surface,
     borderRadius: 16,
@@ -78,11 +79,6 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     borderWidth: 1,
     borderColor: palette.border,
-    shadowColor: "#04110A",
-    shadowOpacity: 0.35,
-    shadowOffset: { width: 0, height: 8 },
-    shadowRadius: 16,
-    elevation: 6,
   },
   optionButton: {
     marginVertical: 0,

--- a/app/leaderboard.tsx
+++ b/app/leaderboard.tsx
@@ -4,7 +4,6 @@ import { useFocusEffect } from "@react-navigation/native";
 import { getActivePlayer, getScores, subscribeActivePlayer } from "../src/storage";
 import type { GameMode, PlayerProfile, ScorePayload } from "../src/types";
 import { palette } from "../src/theme";
-import { PlayerSwitcher } from "../src/ui";
 
 const modeLabels: Record<GameMode, string> = {
   SIMPLE: "Simple",
@@ -320,7 +319,16 @@ export default function LeaderboardScreen() {
     () => (
       <View>
         <View style={styles.topRow}>
-          <PlayerSwitcher style={styles.switcher} onPlayerChange={(player) => setActivePlayer(player)} />
+          <View style={styles.playerSummary}>
+            <Text style={styles.playerSummaryTitle}>
+              {activePlayer ? `${activePlayer.name}'s timeline` : "No active player selected"}
+            </Text>
+            <Text style={styles.playerSummaryHint}>
+              {activePlayer
+                ? "Switch profiles from any solo results screen."
+                : "Finish a solo run to choose where scores are saved."}
+            </Text>
+          </View>
           <TouchableOpacity
             style={[styles.chartToggle, showCharts && styles.chartToggleActive]}
             onPress={() => setShowCharts((prev) => !prev)}
@@ -467,10 +475,12 @@ const styles = StyleSheet.create({
   topRow: {
     flexDirection: "row",
     justifyContent: "space-between",
-    alignItems: "center",
+    alignItems: "flex-start",
     marginBottom: 16,
   },
-  switcher: { marginRight: 12 },
+  playerSummary: { flex: 1, paddingRight: 12 },
+  playerSummaryTitle: { color: palette.textPrimary, fontSize: 18, fontWeight: "700" },
+  playerSummaryHint: { color: palette.textSecondary, fontSize: 12, marginTop: 4, lineHeight: 16 },
   chartToggle: {
     paddingVertical: 8,
     paddingHorizontal: 14,

--- a/app/local.tsx
+++ b/app/local.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import { GameScreen, GameAttemptResult } from "../src/gameplay";
-import { MenuButton, PlayerSwitcher } from "../src/ui";
+import { MenuButton } from "../src/ui";
 import { palette } from "../src/theme";
 import { getPlayers, setActivePlayer } from "../src/storage";
 import type { GameMode, PlayerProfile } from "../src/types";
@@ -30,6 +30,8 @@ export default function LocalMultiplayerScreen() {
   const [turn, setTurn] = useState<TurnState>({ round: 0, shot: 0, playerIndex: 0 });
   const [sessionActive, setSessionActive] = useState(false);
   const [sessionComplete, setSessionComplete] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const [completedMode, setCompletedMode] = useState<GameMode | null>(null);
   const [awaitingAdvance, setAwaitingAdvance] = useState(false);
   const [advanceLabel, setAdvanceLabel] = useState("Next attempt");
   const nextTurnRef = useRef<TurnState | null>(null);
@@ -83,13 +85,31 @@ export default function LocalMultiplayerScreen() {
             ? Math.round(attempts.reduce((sum, attempt) => sum + attempt.score, 0) / attempts.length)
             : null
         );
+        const attempts = rounds.flat();
         const total = averages.reduce((sum, value) => sum + (value ?? 0), 0);
-        return { player, rounds, averages, total };
+        const highScore = attempts.length ? Math.max(...attempts.map((attempt) => attempt.score)) : null;
+        const fastestReaction = attempts.length
+          ? Math.min(...attempts.map((attempt) => attempt.reactionMs))
+          : null;
+        const tightestMiss = attempts.length
+          ? Math.min(...attempts.map((attempt) => attempt.averageDistancePx))
+          : null;
+        return { player, rounds, averages, total, highScore, fastestReaction, tightestMiss, attemptCount: attempts.length };
       })
       .sort((a, b) => b.total - a.total);
   }, [sessionPlayers, sessionRecords]);
 
   const currentPlayer = sessionPlayers[turn.playerIndex];
+
+  const activeModeDetail = useMemo(
+    () => modeOptions.find((mode) => mode.key === sessionMode) ?? modeOptions[0],
+    [sessionMode]
+  );
+
+  const completedModeDetail = useMemo(
+    () => (completedMode ? modeOptions.find((mode) => mode.key === completedMode) ?? null : null),
+    [completedMode]
+  );
 
   const handleStartSession = useCallback(async () => {
     const participants = selectedPlayers;
@@ -100,6 +120,8 @@ export default function LocalMultiplayerScreen() {
     setSessionRecords(createEmptyRecords(participants));
     setTurn({ round: 0, shot: 0, playerIndex: 0 });
     setSessionComplete(false);
+    setShowResults(false);
+    setCompletedMode(sessionMode);
     setSessionActive(true);
     setAwaitingAdvance(false);
     setAdvanceLabel("Next attempt");
@@ -108,7 +130,7 @@ export default function LocalMultiplayerScreen() {
     } catch (error) {
       console.warn("Unable to set active player", error);
     }
-  }, [selectedPlayers, createEmptyRecords]);
+  }, [selectedPlayers, createEmptyRecords, sessionMode]);
 
   const handleAttemptComplete = useCallback(
     (attempt: GameAttemptResult) => {
@@ -169,6 +191,7 @@ export default function LocalMultiplayerScreen() {
       if (sessionComplete) {
         setAwaitingAdvance(false);
         setSessionActive(false);
+        setShowResults(true);
         return;
       }
       const nextTurn = nextTurnRef.current;
@@ -194,13 +217,79 @@ export default function LocalMultiplayerScreen() {
 
   return (
     <View style={styles.safe}>
-      {sessionActive ? (
+      {showResults ? (
+        <ScrollView style={styles.resultsScroll} contentContainerStyle={styles.resultsContent}>
+          <Text style={styles.title}>Match results</Text>
+          <Text style={styles.subtitle}>
+            {(completedModeDetail?.label ?? activeModeDetail?.label ?? "Normal")} mode · {ROUNDS} rounds · {TRIES_PER_ROUND} shots each
+          </Text>
+          {standings.length ? (
+            <>
+              <View style={styles.resultsHighlight}>
+                <Text style={styles.resultsHighlightLabel}>Champion</Text>
+                <Text style={styles.resultsHighlightName}>{standings[0].player.name}</Text>
+                <Text style={styles.resultsHighlightScore}>{`${standings[0].total} pts`}</Text>
+              </View>
+              {standings.map((entry, index) => (
+                <View key={entry.player.id} style={styles.resultsPlayerCard}>
+                  <View style={styles.resultsPlayerHeader}>
+                    <Text style={styles.resultsPlayerName}>{`${index + 1}. ${entry.player.name}`}</Text>
+                    <Text style={styles.resultsPlayerTotal}>{entry.total}</Text>
+                  </View>
+                  <View style={styles.resultsRoundsRow}>
+                    {entry.averages.map((avg, roundIndex) => (
+                      <View key={`${entry.player.id}-round-${roundIndex}`} style={styles.resultsRoundChip}>
+                        <Text style={styles.resultsRoundLabel}>{`R${roundIndex + 1}`}</Text>
+                        <Text style={styles.resultsRoundValue}>{avg !== null ? avg : "--"}</Text>
+                      </View>
+                    ))}
+                  </View>
+                  <View style={styles.resultsStatsRow}>
+                    <View style={styles.resultsStatBlock}>
+                      <Text style={styles.resultsStatLabel}>Best score</Text>
+                      <Text style={styles.resultsStatValue}>{entry.highScore ?? "--"}</Text>
+                    </View>
+                    <View style={styles.resultsStatBlock}>
+                      <Text style={styles.resultsStatLabel}>Fastest</Text>
+                      <Text style={styles.resultsStatValue}>
+                        {entry.fastestReaction !== null ? `${entry.fastestReaction} ms` : "--"}
+                      </Text>
+                    </View>
+                    <View style={[styles.resultsStatBlock, styles.resultsStatBlockLast]}>
+                      <Text style={styles.resultsStatLabel}>Tightest miss</Text>
+                      <Text style={styles.resultsStatValue}>
+                        {entry.tightestMiss !== null ? `${Math.round(entry.tightestMiss)} px` : "--"}
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              ))}
+            </>
+          ) : (
+            <Text style={styles.emptyMessage}>Complete a session to see the standings.</Text>
+          )}
+          <View style={styles.resultsActions}>
+            <MenuButton
+              title={selectedPlayers.length >= 2 ? "Run it back" : "Select players to rematch"}
+              onPress={() => {
+                void handleStartSession();
+              }}
+              disabled={selectedPlayers.length < 2}
+            />
+            <MenuButton
+              title="Back to setup"
+              onPress={() => setShowResults(false)}
+              style={styles.resultsBackButton}
+            />
+          </View>
+        </ScrollView>
+      ) : sessionActive ? (
         <>
           <ScrollView style={styles.sessionScroll} contentContainerStyle={styles.sessionContent}>
             <View style={styles.header}>
               <Text style={styles.title}>Local multiplayer</Text>
-              <PlayerSwitcher style={styles.headerSwitcher} />
               <Text style={styles.subtitle}>{turnLabel}</Text>
+              <Text style={styles.modeLabel}>Mode · {activeModeDetail?.label ?? sessionMode}</Text>
               {currentPlayer && (
                 <Text style={styles.currentPlayer}>{`Current shooter: ${currentPlayer.name}`}</Text>
               )}
@@ -218,7 +307,10 @@ export default function LocalMultiplayerScreen() {
                       {entry.averages.map((avg, index) => (
                         <Text
                           key={`${entry.player.id}-round-${index}`}
-                          style={[styles.standingRoundValue, avg !== null ? styles.standingRoundValueFilled : styles.standingRoundValueEmpty]}
+                          style={[
+                            styles.standingRoundValue,
+                            avg !== null ? styles.standingRoundValueFilled : styles.standingRoundValueEmpty,
+                          ]}
                         >
                           {avg !== null ? avg : "--"}
                         </Text>
@@ -234,7 +326,6 @@ export default function LocalMultiplayerScreen() {
             <GameScreen
               mode={sessionMode}
               persistScore={false}
-              showPlayerSwitcher={false}
               onAttemptComplete={handleAttemptComplete}
               renderResultActions={({ reset }) => (
                 <MenuButton
@@ -249,12 +340,14 @@ export default function LocalMultiplayerScreen() {
       ) : (
         <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
           <Text style={styles.title}>Local multiplayer</Text>
-          <PlayerSwitcher style={styles.selectionSwitcher} />
           <Text style={styles.subtitle}>
             Select at least two players and a mode. Each competitor shoots {TRIES_PER_ROUND} times per round for {ROUNDS}
             rounds. Scores are averaged per round and summed to crown the champion.
           </Text>
-          <View style={styles.section}> 
+          <Text style={styles.helperText}>
+            Profiles rotate automatically during play. Change the active profile from a solo results screen.
+          </Text>
+          <View style={styles.section}>
             <Text style={styles.sectionTitle}>Players</Text>
             {players.length ? (
               players.map((player) => {
@@ -306,7 +399,9 @@ export default function LocalMultiplayerScreen() {
           )}
           <MenuButton
             title={selectedPlayers.length >= 2 ? "Start match" : "Pick at least two players"}
-            onPress={handleStartSession}
+            onPress={() => {
+              void handleStartSession();
+            }}
             disabled={selectedPlayers.length < 2}
             style={styles.startButton}
           />
@@ -320,13 +415,15 @@ const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: palette.background },
   scroll: { flex: 1 },
   sessionScroll: { flex: 1 },
+  resultsScroll: { flex: 1 },
   content: { padding: 20, paddingBottom: 32 },
   sessionContent: { padding: 20, paddingBottom: 24 },
+  resultsContent: { padding: 20, paddingBottom: 32 },
   title: { color: palette.textPrimary, fontSize: 26, fontWeight: "800", marginBottom: 12 },
-  subtitle: { color: palette.textSecondary, fontSize: 13, marginBottom: 16, lineHeight: 18 },
-  selectionSwitcher: { alignSelf: "flex-start", marginBottom: 12 },
+  subtitle: { color: palette.textSecondary, fontSize: 13, marginBottom: 12, lineHeight: 18 },
+  helperText: { color: palette.textSecondary, fontSize: 12, marginBottom: 20 },
   header: { marginBottom: 16 },
-  headerSwitcher: { marginTop: 12, alignSelf: "flex-start" },
+  modeLabel: { color: palette.textSecondary, fontSize: 12, textTransform: "uppercase", letterSpacing: 1 },
   currentPlayer: { color: palette.textPrimary, fontSize: 14, marginTop: 8 },
   section: { marginBottom: 24 },
   sectionTitle: { color: palette.textPrimary, fontSize: 18, fontWeight: "700", marginBottom: 12 },
@@ -410,5 +507,47 @@ const styles = StyleSheet.create({
   },
   resultsTitle: { color: palette.textPrimary, fontSize: 16, fontWeight: "700" },
   resultsText: { color: palette.textSecondary, marginTop: 4 },
+  resultsHighlight: {
+    backgroundColor: palette.surface,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 16,
+    marginBottom: 16,
+  },
+  resultsHighlightLabel: { color: palette.textSecondary, fontSize: 12, letterSpacing: 1, textTransform: "uppercase" },
+  resultsHighlightName: { color: palette.textPrimary, fontSize: 22, fontWeight: "800", marginTop: 8 },
+  resultsHighlightScore: { color: palette.textSecondary, fontSize: 12, marginTop: 4 },
+  resultsPlayerCard: {
+    backgroundColor: palette.surface,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: palette.border,
+    padding: 16,
+    marginBottom: 16,
+  },
+  resultsPlayerHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 12 },
+  resultsPlayerName: { color: palette.textPrimary, fontSize: 16, fontWeight: "700" },
+  resultsPlayerTotal: { color: palette.textPrimary, fontSize: 18, fontWeight: "800" },
+  resultsRoundsRow: { flexDirection: "row", flexWrap: "wrap", marginBottom: 12 },
+  resultsRoundChip: {
+    backgroundColor: palette.surfaceAlt,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: palette.border,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  resultsRoundLabel: { color: palette.textSecondary, fontSize: 11, letterSpacing: 0.5 },
+  resultsRoundValue: { color: palette.textPrimary, fontSize: 14, fontWeight: "700", marginTop: 2 },
+  resultsStatsRow: { flexDirection: "row", justifyContent: "space-between" },
+  resultsStatBlock: { flex: 1, marginRight: 12 },
+  resultsStatBlockLast: { marginRight: 0 },
+  resultsStatLabel: { color: palette.textSecondary, fontSize: 11, textTransform: "uppercase", letterSpacing: 0.5 },
+  resultsStatValue: { color: palette.textPrimary, fontSize: 14, fontWeight: "700", marginTop: 4 },
+  resultsActions: { marginTop: 12 },
+  resultsBackButton: { marginTop: 12 },
   gameWrapper: { flex: 1, minHeight: 480 },
 });

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { View, StyleSheet, BackHandler, Text } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import { router } from "expo-router";
-import { MenuButton, PlayerSwitcher } from "../src/ui";
+import { MenuButton } from "../src/ui";
 import { palette } from "../src/theme";
 import { getActivePlayer, subscribeActivePlayer } from "../src/storage";
 import type { PlayerProfile } from "../src/types";
@@ -35,11 +35,10 @@ export default function MainMenuScreen() {
   return (
     <View style={styles.safe}>
       <View style={styles.container}>
-        <View style={styles.titleRow}>
+        <View style={styles.header}>
           <Text style={styles.title}>Predict Aim</Text>
-          <PlayerSwitcher style={styles.switcher} onPlayerChange={(player) => setActivePlayer(player)} />
+          <Text style={styles.subtitle}>Sharpen your prediction timing across dynamic targets.</Text>
         </View>
-        <Text style={styles.subtitle}>Sharpen your prediction timing across dynamic targets.</Text>
         <View style={styles.playerCard}>
           <Text style={styles.playerCardLabel}>Active player</Text>
           <Text style={styles.playerCardName}>{activePlayer?.name ?? "None selected"}</Text>
@@ -64,10 +63,9 @@ export default function MainMenuScreen() {
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: palette.background },
   container: { flex: 1, justifyContent: "center", padding: 24 },
-  titleRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
-  title: { color: palette.textPrimary, fontSize: 30, fontWeight: "800", flexShrink: 1, paddingRight: 12 },
-  switcher: { marginLeft: 12 },
-  subtitle: { color: palette.textSecondary, fontSize: 14, marginTop: 8, marginBottom: 24 },
+  header: { marginBottom: 24 },
+  title: { color: palette.textPrimary, fontSize: 30, fontWeight: "800" },
+  subtitle: { color: palette.textSecondary, fontSize: 14, marginTop: 8 },
   playerCard: {
     backgroundColor: palette.surface,
     borderRadius: 16,

--- a/src/gameplay.tsx
+++ b/src/gameplay.tsx
@@ -527,7 +527,6 @@ export interface GameScreenProps {
   persistScore?: boolean;
   onAttemptComplete?: (result: GameAttemptResult) => void;
   renderResultActions?: ResultActionRenderer;
-  showPlayerSwitcher?: boolean;
 }
 
 export function GameScreen({
@@ -536,7 +535,6 @@ export function GameScreen({
   persistScore = true,
   onAttemptComplete,
   renderResultActions,
-  showPlayerSwitcher = true,
 }: GameScreenProps) {
   const isExtreme = mode === "EXTREME";
   const [phase, setPhase] = useState<Phase>("observe");
@@ -969,15 +967,8 @@ export function GameScreen({
   return (
     <View style={styles.safe}>
       <View style={styles.header}>
-        <View style={styles.headerRow}>
-          <View style={styles.titleGroup}>
-            <Text style={styles.modeTitle}>{detail.label} Mode</Text>
-            <Text style={styles.modeSubtitle}>{detail.description}</Text>
-          </View>
-          {showPlayerSwitcher && (
-            <PlayerSwitcher style={styles.switcher} onPlayerChange={(player) => setActivePlayerName(player?.name ?? null)} />
-          )}
-        </View>
+        <Text style={styles.modeTitle}>{detail.label} Mode</Text>
+        <Text style={styles.modeSubtitle}>{detail.description}</Text>
         <Text style={styles.playerBadge}>
           {activePlayerName ? `Active player · ${activePlayerName}` : "No active player selected"}
         </Text>
@@ -1050,11 +1041,20 @@ export function GameScreen({
               <Text style={styles.overlaySubtitle}>{phase === "guess" ? guessSubtitle : phaseCopy[phase].subtitle}</Text>
             </View>
           )}
-          {phase === "result" && result && (
-            <View style={styles.resultOverlay}>
-              <View style={styles.resultsCard}>
-                <Text style={styles.resultsTitle}>How close were you?</Text>
-                <View style={styles.resultsList}>
+        {phase === "result" && result && (
+          <View style={styles.resultOverlay}>
+            <View style={styles.resultsCard}>
+              {persistScore && (
+                <View style={styles.resultSwitcherGroup}>
+                  <Text style={styles.resultSwitcherLabel}>Score destination</Text>
+                  <PlayerSwitcher
+                    style={styles.resultSwitcher}
+                    onPlayerChange={(player) => setActivePlayerName(player?.name ?? null)}
+                  />
+                </View>
+              )}
+              <Text style={styles.resultsTitle}>How close were you?</Text>
+              <View style={styles.resultsList}>
                   {resultItems.map((item, index) => (
                     <Animated.View
                       key={item.key}
@@ -1142,11 +1142,8 @@ export function GameScreen({
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: palette.background },
   header: { paddingHorizontal: 20, paddingTop: 24, paddingBottom: 10 },
-  headerRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
-  titleGroup: { flexShrink: 1, paddingRight: 12 },
   modeTitle: { color: palette.textPrimary, fontSize: 24, fontWeight: "800" },
   modeSubtitle: { color: palette.textSecondary, fontSize: 13, marginTop: 4 },
-  switcher: { marginTop: -6 },
   playerBadge: {
     color: palette.textSecondary,
     fontSize: 12,
@@ -1251,6 +1248,15 @@ const styles = StyleSheet.create({
   resultsList: {
     marginTop: 12,
   },
+  resultSwitcherGroup: { marginBottom: 16 },
+  resultSwitcherLabel: {
+    color: palette.textSecondary,
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+    marginBottom: 8,
+  },
+  resultSwitcher: { alignSelf: "flex-start" },
   resultItem: {
     marginBottom: 12,
     alignItems: "center",


### PR DESCRIPTION
## Summary
- simplify the main menu and play selection screens by removing the global player switcher and adding a back affordance
- move player switching into the solo results overlay while refreshing leaderboard messaging about active profiles
- introduce a detailed local multiplayer recap view with per-player breakdowns and clearer setup guidance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1401cc2208330a34e3b484538ab0b